### PR TITLE
style(#20): main width, margin 수정, box-sizing 수정

### DIFF
--- a/front-end/src/styles/main.scss
+++ b/front-end/src/styles/main.scss
@@ -1,3 +1,6 @@
+* {
+  box-sizing: border-box;
+}
 body {
   min-height: 100vh;
 }
@@ -9,9 +12,9 @@ body {
 }
 main {
   flex-grow: 1;
-  color: red;
   padding-top: 6rem;
-  max-width: 1400px;
+  max-width: 2000px;
+  width: 100%;
   margin: 0 auto;
 }
 header {
@@ -19,4 +22,6 @@ header {
   width: 100%;
   background-color: rgba(255, 255, 255, 0.4);
   backdrop-filter: blur(2px);
+  z-index: 10;
+  border-bottom: 1px solid lightgray;
 }


### PR DESCRIPTION
### 이슈 넘버
- resolved #20 
- 
### 이런 이유로 코드를 변경했어요
- main section의 디자인 문제
- 
### 이런 작업을 했어요
- box-sizing : border-box
- max-width
- width
### 리뷰어는 여기에 집중해주시면 좋아요
- 스크린 샷을 봐주세용
- 

### 향후 이런 계획이 있어요
- 디자인을 입힐 계획이 있어요
- 
### 스크린샷
- width:100% 적용 전
<img width="1248" alt="스크린샷 2023-02-03 오후 8 59 50" src="https://user-images.githubusercontent.com/82891332/216598876-88bde829-ec79-4e1e-b567-96b5e757c51d.png">

- max-width 적용 전
<img width="1248" alt="스크린샷 2023-02-03 오후 9 00 03" src="https://user-images.githubusercontent.com/82891332/216598970-7ce5feba-351c-41b7-a79f-2fd0abfb3a79.png">

- 모두 적용 후
<img width="1248" alt="스크린샷 2023-02-03 오후 9 00 11" src="https://user-images.githubusercontent.com/82891332/216598996-6276918b-4188-4dcb-a54f-aecfd05890a3.png">

