### PR TITLE
Be/feature/#22 백엔드 개발환경에 lombok, swagger 설정 추가

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -23,8 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'mysql:mysql-connector-java:8.0.21'
 
-	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
-	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+	// swagger dependency
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -8,6 +8,12 @@ group = 'com.tdd'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -15,8 +21,14 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'mysql:mysql-connector-java:8.0.21'
+
+	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 }
 

--- a/back-end/src/main/java/com/tdd/backend/config/SwaggerConfig.java
+++ b/back-end/src/main/java/com/tdd/backend/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.tdd.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.OAS_30)
+			.useDefaultResponseMessages(false)
+			.apiInfo(apiInfo())
+			.select()
+			.apis(RequestHandlerSelectors.any())
+			.paths(PathSelectors.any())
+			.build();
+	}
+
+	private ApiInfo apiInfo() {
+		return new ApiInfoBuilder()
+			.title("티디디 Spring Boot REST API")
+			.version("1.0.0")
+			.description("사용자의 자동차 경험을 공유하는 시승 플랫폼 '티디디'의 swagger api 입니다.")
+			.build();
+	}
+}


### PR DESCRIPTION
### 이슈 넘버
- resolved #22 

### 이런 이유로 코드를 변경했어요
- API 문서 자동화를 위한 툴이 필요함.
- 2월 3일자 주간피드백에서 호눅스님께서 롬복 사용해도 된다고 하셨음.
### 이런 작업을 했어요
- swagger3.0 의존성 및 config 클래스 추가
- lombok 의존성 적용

###  ❗ Swagger3.0 주의사항 ❗ 
- yml파일에 아래 property 추가해주셔야 정상적으로 서버가 구동됩니다!
```yml
spring:
  mvc:
    pathmatch:
      matching-strategy: ant_path_matcher
```
- swagger3.0부터는 접속 url이 http://localhost:8080/swagger-ui/index.html 로 변경되었습니다. API docs 접속 시 서버 구동 후 해당 url로 접속해주세요.

### 향후 계획
- API 문서화를 Swagger에 바로 하려고 했는데 아직 미완성된 부분도 있고 비어있는 컨트롤러 메서드를 마구 만들어서 푸쉬하는게 이상하다는 생각이 갑자기 들어서 하지 않았습니다. API 초안은 우선은 작성된 거 살짝 가다듬어 문서형태로 따로 공유하겠습니다.