### PR TITLE
Be/feature/#28 API 명세 Swagger 자동화 작업

### DIFF
--- a/back-end/src/main/java/com/tdd/backend/config/SwaggerConfig.java
+++ b/back-end/src/main/java/com/tdd/backend/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
 
 	private ApiInfo apiInfo() {
 		return new ApiInfoBuilder()
-			.title("티디디 Spring Boot REST API")
+			.title("티디디 Spring Boot Web API")
 			.version("1.0.0")
 			.description("사용자의 자동차 경험을 공유하는 시승 플랫폼 '티디디'의 swagger api 입니다.")
 			.build();

--- a/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
+++ b/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
@@ -1,27 +1,49 @@
 package com.tdd.backend.post;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class PostCotroller {
 	private final PostService postService;
 
-	@Operation(summary = "차량 공유하기 요청", description = "차량 공유하기 시 Post 정보가 insert 되어야 합니다.")
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "OK"),
-		@ApiResponse(responseCode = "302", description = "메인 페이지로 REDIRECT"),
-		@ApiResponse(responseCode = "404", description = "NOT FOUND"),
-		@ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
-	})
 	@PostMapping("/shares")
+	@Operation(summary = "차량 공유하기 요청", description = "차량 공유하기 시 Post 정보가 insert 되어야 합니다.")
+	@ApiResponse(responseCode = "302", description = "메인 페이지로 REDIRECT")
 	public void shares() {
+		// 요청: 차 이름, 위치, 옵션들, 동승여부, 사용자의 이름, 전화번호, 날짜 리스트,  요구사항
+		// 302 REDIRECT index.html
+	}
 
+	@GetMapping("/drives/locations")
+	@Operation(summary = "시승가능한 차량 요청", description = "차종과 선택한 옵션 리스트를 요청 받으면 해당하는 Post의 location 리스트로 응답해야 함.")
+	public void getLocations() {
+		// 요청: 차 이름, 옵션 리스트
+		// 응답 : location 리스트 (postId, locationX, locationY)
+	}
+
+	@GetMapping("/drives/{postId}")
+	@Operation(summary = "location 리스트에서 하나의 포스트 선택 시에 대한 요청", description = "포스트의 해당 차종과 옵션 목록으로 응답해야 함.")
+	public void getPost(@PathVariable Long postId) {
+		// 응답: 차량 이름, 옵션목록
+	}
+
+	@GetMapping("/drives/appointments/{postId}")
+	@Operation(summary = "해당 Post의 예약현황(날짜) 요청", description = "postId에 해당하는 포스트가 가진 Appointment 리스트로 응답해야 함.")
+	public void getAppointments(@PathVariable Long postId) {
+		// 응답 :  appointment 리스트
+	}
+
+	@PostMapping("/appointments/{appointmentId}")
+	@Operation(summary = "최종적인 예약 요청", description = "시승하기에 대한 사용자의 최종적인 요청으로 Appointment의 상태를 승낙으로 Update해야 함.")
+	public void requestAppointment(@PathVariable Long appointmentId) {
+		// 요청 : appointment id
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
+++ b/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
@@ -1,6 +1,7 @@
 package com.tdd.backend.post;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,7 +42,7 @@ public class PostCotroller {
 		// 응답 :  appointment 리스트
 	}
 
-	@PostMapping("/appointments/{appointmentId}")
+	@PatchMapping("/appointments/{appointmentId}")
 	@Operation(summary = "최종적인 예약 요청", description = "시승하기에 대한 사용자의 최종적인 요청으로 Appointment의 상태를 승낙으로 Update해야 함.")
 	public void requestAppointment(@PathVariable Long appointmentId) {
 		// 요청 : appointment id

--- a/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
+++ b/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class PostCotroller {
 	private final PostService postService;
 
-	@PostMapping("/shares")
+	@PostMapping("/sharing")
 	@Operation(summary = "차량 공유하기 요청", description = "차량 공유하기 시 Post 정보가 insert 되어야 합니다.")
 	@ApiResponse(responseCode = "302", description = "메인 페이지로 REDIRECT")
 	public void shares() {
@@ -23,20 +23,20 @@ public class PostCotroller {
 		// 302 REDIRECT index.html
 	}
 
-	@GetMapping("/drives/locations")
+	@GetMapping("/test-driving/locations")
 	@Operation(summary = "시승가능한 차량 요청", description = "차종과 선택한 옵션 리스트를 요청 받으면 해당하는 Post의 location 리스트로 응답해야 함.")
 	public void getLocations() {
 		// 요청: 차 이름, 옵션 리스트
 		// 응답 : location 리스트 (postId, locationX, locationY)
 	}
 
-	@GetMapping("/drives/{postId}")
+	@GetMapping("/test-driving/{postId}")
 	@Operation(summary = "location 리스트에서 하나의 포스트 선택 시에 대한 요청", description = "포스트의 해당 차종과 옵션 목록으로 응답해야 함.")
 	public void getPost(@PathVariable Long postId) {
 		// 응답: 차량 이름, 옵션목록
 	}
 
-	@GetMapping("/drives/appointments/{postId}")
+	@GetMapping("/test-driving/appointments/{postId}")
 	@Operation(summary = "해당 Post의 예약현황(날짜) 요청", description = "postId에 해당하는 포스트가 가진 Appointment 리스트로 응답해야 함.")
 	public void getAppointments(@PathVariable Long postId) {
 		// 응답 :  appointment 리스트

--- a/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
+++ b/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
@@ -1,0 +1,27 @@
+package com.tdd.backend.post;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class PostCotroller {
+	private final PostService postService;
+
+	@Operation(summary = "차량 공유하기 요청", description = "차량 공유하기 시 Post 정보가 insert 되어야 합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "OK"),
+		@ApiResponse(responseCode = "302", description = "메인 페이지로 REDIRECT"),
+		@ApiResponse(responseCode = "404", description = "NOT FOUND"),
+		@ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+	})
+	@PostMapping("/shares")
+	public void shares() {
+
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
+++ b/back-end/src/main/java/com/tdd/backend/post/PostCotroller.java
@@ -46,4 +46,14 @@ public class PostCotroller {
 	public void requestAppointment(@PathVariable Long appointmentId) {
 		// 요청 : appointment id
 	}
+
+	/**
+	 * 특정 차종에 대한 모든 옵션 리스트 렌더링
+	 */
+	@GetMapping("/options?carName={name}")
+	@Operation(summary = "특정 차종에 대한 모든 옵션 리스트 렌더링", description = "시승, 공유 모두 사용하며, 차종 요청에 대해 가능한 모든 옵션을 제공해야 함.")
+	public void getOptions(@PathVariable String name) {
+		// 응답: {name}에 존재하는 모든 옵션 리스트 JSON
+	}
+
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -1,0 +1,30 @@
+package com.tdd.backend.user;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@Operation(summary = "유저 회원가입 요청", description = "User SignUp request")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "OK"),
+		@ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+		@ApiResponse(responseCode = "404", description = "NOT FOUND"),
+		@ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+	})
+	@PostMapping("/signup")
+	public void signup() {
+	}
+
+	@PostMapping("/login")
+	public void login() {
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -1,14 +1,14 @@
 package com.tdd.backend.user;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class UserController {
 	private final UserService userService;


### PR DESCRIPTION
### 이슈 넘버
- resolved #28 
### 이런 이유로 코드를 변경했어요
- API Spec자동화 도구인 Swagger를 적극 활용하여 작성한 API 명세를 별도의 문서로 작업했을 때의 단점을 보완하고 생산성을 증가시키기 위함.
### 이런 작업을 했어요
- 작성한 API 명세 초안을 기반으로 UserController, PostController에 해당하는 컨트롤러 메서드와 description을 추가하였습니다.

### 리뷰어는 여기에 집중해주시면 좋아요
- 작업을 하며 API 명세 초안에서 살짝 놓쳤던 부분이 있어 수정하였습니다. (POST -> PATCH로 바꿈, PathVariable 빠져 있어 추가함)
- 모든 메서드는 void 응답으로 되어 있으며, **❗ 요청 및 응답에 필요한 DTO나 로직 등은 작성되어 있지 않습니다.❗**
- 각 API에 필요한 정보들은 **주석과 description** 에 추가해두었습니다. 응답에 대한 설명을 추가하고 싶다면 회원가입 메서드에 적어둔 예시를 참고하여 작성하시면 됩니다.

### ✨  초안대로 작성되어 있기 때문에 메서드를 자유롭게 추가, 수정 및 삭제해주시면 됩니다!
(패키지 구조도 더 나은 설계에 대해 고민하면 좋을 것 같습니다. 현재는 PostController에 대부분 서비스 로직에 대한 컨트롤러 메서드가 집중되어 있습니다.)