### PR TITLE
[Fe] fix: router 로직 전체적으로 수정

### DIFF
--- a/front-end/src/app.ts
+++ b/front-end/src/app.ts
@@ -1,6 +1,8 @@
 import Component from '@/core/Component';
 import { Footer } from './components/Footer/Footer';
 import { Navbar } from './components/Navbar/Navbar';
+import { Router } from './core/Router';
+import { attachRouterToAnchor } from './utils/navigatator';
 import { qs } from './utils/querySelector';
 
 export class App extends Component {
@@ -11,10 +13,16 @@ export class App extends Component {
     <footer></footer>
     `;
   }
+
+  setEvent(): void {
+    this.addEvent('click', 'a', attachRouterToAnchor);
+  }
   mounted(): void {
     const $header = qs('header') as HTMLElement;
+    const $main = qs('main') as HTMLElement;
     const $footer = qs('footer') as HTMLElement;
     new Navbar($header);
+    new Router($main);
     new Footer($footer);
   }
 }

--- a/front-end/src/components/Navbar/Navbar.ts
+++ b/front-end/src/components/Navbar/Navbar.ts
@@ -1,30 +1,8 @@
 import Component from '@/core/Component';
-import { Router } from '@/core/Router';
 import { qs } from '@/utils/querySelector';
 import styles from './Navbar.module.scss';
 
 export class Navbar extends Component {
-  setup(): void {
-    const $main = qs('main') as HTMLElement;
-    this.state = {
-      routes: [
-        {
-          path: /^\/$/,
-          element: () => console.log('main'),
-        },
-        { path: /^\/aboutus$/, element: () => console.log('about us') },
-        { path: /^\/share$/, element: () => console.log('share page') },
-        {
-          path: /^\/experience$/,
-          element: () => console.log('experience page'),
-        },
-        {
-          path: /^\/post\/[\w]+$/,
-          element: () => console.log('query example'),
-        },
-      ],
-    };
-  }
   template(): string {
     return `
     <div class="${styles['progress-container']}">
@@ -34,8 +12,8 @@ export class Navbar extends Component {
       <a href="/" class="${styles.logo}">T D D</a>
       <ul>
         <li><a href="/aboutus">ABOUT US</a></li>
-        <li><a href="/share">공유하기</a></li>
-        <li><a href="/experience">경험하기</a></li>
+        <li><a href="/sharing">공유하기</a></li>
+        <li><a href="/experiencing">경험하기</a></li>
         <button class="${styles['login-button']}">login</button>
         <button class="${styles['logout-button']} ${styles.hidden}">logout</button>
       </ul>
@@ -45,17 +23,6 @@ export class Navbar extends Component {
   mounted(): void {
     this.updateProgress();
     window.addEventListener('scroll', this.updateProgress);
-  }
-
-  setEvent(): void {
-    const router = new Router(this.state.routes);
-    const BASE_URL = 'http://localhost:5173';
-    this.addEvent('click', 'a', (e: Event) => {
-      e.preventDefault();
-      const target = e.target as HTMLAnchorElement;
-      const targetURL = target.href.replace(BASE_URL, '');
-      router.navigate(targetURL);
-    });
   }
 
   updateProgress() {

--- a/front-end/src/components/Navbar/Navbar.ts
+++ b/front-end/src/components/Navbar/Navbar.ts
@@ -9,11 +9,11 @@ export class Navbar extends Component {
       <div class="${styles['progress-bar']}"></div>
     </div>
     <nav class="${styles.navbar}">
-      <a href="/" class="${styles.logo}">T D D</a>
+      <a data-link href="/" class="${styles.logo}">T D D</a>
       <ul>
-        <li><a href="/aboutus">ABOUT US</a></li>
-        <li><a href="/sharing">공유하기</a></li>
-        <li><a href="/experiencing">경험하기</a></li>
+        <li><a data-link href="/aboutus">ABOUT US</a></li>
+        <li><a data-link href="/sharing">공유하기</a></li>
+        <li><a data-link href="/experiencing">경험하기</a></li>
         <button class="${styles['login-button']}">login</button>
         <button class="${styles['logout-button']} ${styles.hidden}">logout</button>
       </ul>

--- a/front-end/src/constants/routeInfo.ts
+++ b/front-end/src/constants/routeInfo.ts
@@ -7,7 +7,6 @@ interface IRoute {
   path: RegExp;
   element: Function;
 }
-export const BASE_URL = 'http://localhost:5173';
 
 export const routes: IRoute[] = [
   { path: /^\/$/, element: Home },

--- a/front-end/src/constants/routeInfo.ts
+++ b/front-end/src/constants/routeInfo.ts
@@ -1,0 +1,19 @@
+import { Home } from '@/components/Home/Home';
+import { Experiencing } from '@/pages/experiencing';
+import { Sharing } from '@/pages/sharing';
+import { AboutUs } from '@/pages/aboutus';
+import { NotFound } from '@/pages/notfound';
+interface IRoute {
+  path: RegExp;
+  element: Function;
+}
+export const BASE_URL = 'http://localhost:5173';
+
+export const routes: IRoute[] = [
+  { path: /^\/$/, element: Home },
+  { path: /^\/aboutus$/, element: AboutUs },
+  { path: /^\/sharing$/, element: Sharing },
+  { path: /^\/experiencing$/, element: Experiencing },
+  //test용
+  { path: /^\/post\/[\w]+$/, element: NotFound },
+];

--- a/front-end/src/core/Router.ts
+++ b/front-end/src/core/Router.ts
@@ -1,16 +1,16 @@
-interface IRoute {
-  path: RegExp;
-  element: Function;
-}
+import { routes } from '@/constants/routeInfo';
+import { NotFound } from '@/pages/notfound';
 
 export class Router {
-  constructor(private routes: IRoute[]) {
+  constructor(private $container: HTMLElement) {
     this.init();
     this.route();
   }
+
   private init() {
-    window.addEventListener('historychange', ({ detail }) => {
-      const { to, isReplace } = detail;
+    window.addEventListener('historychange', (e) => {
+      e.preventDefault();
+      const { to, isReplace } = e.detail;
 
       if (isReplace || to === location.pathname)
         history.replaceState(null, '', to);
@@ -24,21 +24,12 @@ export class Router {
     });
   }
 
-  private findMatchedRoute(this: Router) {
-    return this.routes.find((route) => route.path.test(location.pathname));
+  private findMatchedRoute() {
+    return routes.find((route) => route.path.test(location.pathname));
   }
 
-  private route(this: Router) {
-    this.findMatchedRoute()?.element();
-  }
-
-  navigate(to: string, isReplace: boolean = false): void {
-    const historyChangeEvent = new CustomEvent('historychange', {
-      detail: {
-        to,
-        isReplace,
-      },
-    });
-    dispatchEvent(historyChangeEvent);
+  private route() {
+    const TargetPage = this.findMatchedRoute()?.element || NotFound;
+    new TargetPage(this.$container);
   }
 }

--- a/front-end/src/pages/aboutus.ts
+++ b/front-end/src/pages/aboutus.ts
@@ -1,0 +1,7 @@
+import Component from '@/core/Component';
+
+export class AboutUs extends Component {
+  template(): string {
+    return `<div>about us page</div>`;
+  }
+}

--- a/front-end/src/pages/experiencing.ts
+++ b/front-end/src/pages/experiencing.ts
@@ -1,0 +1,7 @@
+import Component from '@/core/Component';
+
+export class Experiencing extends Component {
+  template(): string {
+    return `<div>Experiencing page</div>`;
+  }
+}

--- a/front-end/src/pages/notfound.ts
+++ b/front-end/src/pages/notfound.ts
@@ -1,0 +1,7 @@
+import Component from '@/core/Component';
+
+export class NotFound extends Component {
+  template(): string {
+    return `<div>NotFound page</div>`;
+  }
+}

--- a/front-end/src/pages/sharing.ts
+++ b/front-end/src/pages/sharing.ts
@@ -1,0 +1,7 @@
+import Component from '@/core/Component';
+
+export class Sharing extends Component {
+  template(): string {
+    return `<div>Sharing page</div>`;
+  }
+}

--- a/front-end/src/utils/navigatator.ts
+++ b/front-end/src/utils/navigatator.ts
@@ -1,0 +1,21 @@
+import { BASE_URL } from '@/constants/routeInfo';
+export const navigate = (to: string, isReplace: boolean = false) => {
+  const historyChangeEvent = new CustomEvent('historychange', {
+    detail: {
+      to,
+      isReplace,
+    },
+  });
+
+  dispatchEvent(historyChangeEvent);
+};
+
+export function attachRouterToAnchor(e: Event) {
+  const $clicked = e.target as HTMLElement;
+  const $anchorTarget = $clicked.closest('a');
+  if (!($anchorTarget instanceof HTMLAnchorElement)) return;
+  e.preventDefault();
+
+  const targetURL = $anchorTarget.href.replace(BASE_URL, '');
+  navigate(targetURL);
+}

--- a/front-end/src/utils/navigatator.ts
+++ b/front-end/src/utils/navigatator.ts
@@ -1,4 +1,3 @@
-import { BASE_URL } from '@/constants/routeInfo';
 export const navigate = (to: string, isReplace: boolean = false) => {
   const historyChangeEvent = new CustomEvent('historychange', {
     detail: {
@@ -17,6 +16,6 @@ export function attachRouterToAnchor(e: Event) {
   if (!$anchorTarget.matches('[data-link]')) return;
   e.preventDefault();
 
-  const targetURL = $anchorTarget.href.replace(BASE_URL, '');
-  navigate(targetURL);
+  const targetURL = $anchorTarget.getAttribute('href');
+  if (targetURL) navigate(targetURL);
 }

--- a/front-end/src/utils/navigatator.ts
+++ b/front-end/src/utils/navigatator.ts
@@ -14,6 +14,7 @@ export function attachRouterToAnchor(e: Event) {
   const $clicked = e.target as HTMLElement;
   const $anchorTarget = $clicked.closest('a');
   if (!($anchorTarget instanceof HTMLAnchorElement)) return;
+  if (!$anchorTarget.matches('[data-link]')) return;
   e.preventDefault();
 
   const targetURL = $anchorTarget.href.replace(BASE_URL, '');


### PR DESCRIPTION
### 이슈 넘버
- resolved #39 
### 이런 이유로 코드를 변경했어요
- navigate 메소드가 router 안에 있어서 navbar 이외의 곳에서는 라우팅이 안됨 
- a 태그에서 이벤트 발생해서 외부링크로 이동할 수 없음
- 
### 이런 작업을 했어요
- navigate 메소드 유틸로 뺐어요
- 라우팅 이벤트 메소드를 따로 정의했어요. 따로 부착해야 돼요
- routeInfo 도 만들었어요
- 이전에는 직접 main에 부착하는 방식이었다면 지금은 routeInfo 에 컴포넌트를 전달하고, router가 가지고있는 $container에 전달받은 컴포넌트를 렌더하는 방식이에요
### 리뷰어는 여기에 집중해주시면 좋아요
- 라우팅을 사용하기 위해선 `a`tag 와 `data-link` 속성을 이용해주세요
- ex)
```ts
<a data-link href="/aboutus">ABOUT US</a>
```
### 이런 위험이나 장애가 있어요
- app 안에서만 작동하도록 되어있어요. 
- 모달이나 기타 등등 main 밖에서 사용하게 될 경우 `attachRouterToAnchor` 메소드를 이벤트로 달아주세요
### 향후 이런 계획이 있어요
- 배포 이후 base url 수정해야 해요.
### 스크린샷
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/82891332/216812703-3d0350ea-2544-4d50-ad37-4b0155b01386.gif)

아래의 스크린샷은 a 태그에서 data-link가 있을 때와 없을 때의 차이를 보여드리는 것이에요
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/82891332/216812707-123ee17e-cc05-4b04-b29a-18d19e1fd478.gif)

