### PR TITLE
[Be] feature (#58) 쿠키 기반 로그인 및 인증 구현

### DIFF
--- a/back-end/src/main/java/com/tdd/backend/auth/AuthResolver.java
+++ b/back-end/src/main/java/com/tdd/backend/auth/AuthResolver.java
@@ -1,5 +1,10 @@
 package com.tdd.backend.auth;
 
+import java.util.Objects;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -7,33 +12,37 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.tdd.backend.user.SessionStorage;
-import com.tdd.backend.user.User;
-import com.tdd.backend.user.data.Session;
+import com.tdd.backend.user.data.UserSession;
 import com.tdd.backend.user.exception.UnauthorizedException;
-//todo : 세션 기반 로그인 유지 기술 및 테스트 코드 구현
+
+import lombok.extern.slf4j.Slf4j;
+
+//todo : 로그인 유지 기술 및 테스트 코드 구현
+@Slf4j
 public class AuthResolver implements HandlerMethodArgumentResolver {
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
 
 		boolean isAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
-		boolean isUserSession = parameter.getParameterType().equals(Session.class);
+		boolean isUserSession = parameter.getParameterType().equals(UserSession.class);
 
 		return isAnnotation && isUserSession;
 	}
 
 	@Override
-	public User resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
 		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
-		String accessToken = webRequest.getParameter("AccessToken");
-		if (accessToken == null || accessToken.equals("")) {
+		Cookie[] cookies = Objects.requireNonNull(request).getCookies();
+		if (cookies.length == 0) {
 			throw new UnauthorizedException();
 		}
 
+		String accessToken = cookies[0].getValue();
 		if (SessionStorage.isSession(accessToken)) {
-			return SessionStorage.getSession(accessToken).getUser();
-
+			return SessionStorage.getSession(accessToken);
 		}
 		throw new UnauthorizedException();
 	}

--- a/back-end/src/main/java/com/tdd/backend/auth/AuthResolver.java
+++ b/back-end/src/main/java/com/tdd/backend/auth/AuthResolver.java
@@ -1,0 +1,40 @@
+package com.tdd.backend.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.tdd.backend.user.SessionStorage;
+import com.tdd.backend.user.User;
+import com.tdd.backend.user.data.Session;
+import com.tdd.backend.user.exception.UnauthorizedException;
+//todo : 세션 기반 로그인 유지 기술 및 테스트 코드 구현
+public class AuthResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+
+		boolean isAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
+		boolean isUserSession = parameter.getParameterType().equals(Session.class);
+
+		return isAnnotation && isUserSession;
+	}
+
+	@Override
+	public User resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+		String accessToken = webRequest.getParameter("AccessToken");
+		if (accessToken == null || accessToken.equals("")) {
+			throw new UnauthorizedException();
+		}
+
+		if (SessionStorage.isSession(accessToken)) {
+			return SessionStorage.getSession(accessToken).getUser();
+
+		}
+		throw new UnauthorizedException();
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/auth/LoginUser.java
+++ b/back-end/src/main/java/com/tdd/backend/auth/LoginUser.java
@@ -1,0 +1,11 @@
+package com.tdd.backend.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
+++ b/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.tdd.backend.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.tdd.backend.auth.AuthResolver;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(new AuthResolver());
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
+++ b/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
@@ -4,12 +4,21 @@ import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.tdd.backend.auth.AuthResolver;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("*")
+			.allowedMethods("*")
+			.maxAge(3000);
+	}
 
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/back-end/src/main/java/com/tdd/backend/exception/ErrorResponse.java
+++ b/back-end/src/main/java/com/tdd/backend/exception/ErrorResponse.java
@@ -4,14 +4,11 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
 	private final String code;

--- a/back-end/src/main/java/com/tdd/backend/exception/ExceptionController.java
+++ b/back-end/src/main/java/com/tdd/backend/exception/ExceptionController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.tdd.backend.user.exception.DuplicateEmailException;
+import com.tdd.backend.user.exception.UserNotFoundException;
 
 @RestControllerAdvice
 public class ExceptionController {
@@ -33,9 +34,19 @@ public class ExceptionController {
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(DuplicateEmailException.class)
-	public ErrorResponse userNotFoundExceptionHandler(DuplicateEmailException ex) {
+	public ErrorResponse duplicateEmailExceptionHandler(DuplicateEmailException ex) {
 		return ErrorResponse.builder()
 			.code(HttpStatus.BAD_REQUEST.toString())
+			.errorMessage(ex.getMessage())
+			.build();
+
+	}
+
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler(UserNotFoundException.class)
+	public ErrorResponse userNotFoundExceptionHandler(UserNotFoundException ex) {
+		return ErrorResponse.builder()
+			.code(HttpStatus.UNAUTHORIZED.toString())
 			.errorMessage(ex.getMessage())
 			.build();
 

--- a/back-end/src/main/java/com/tdd/backend/user/DummyController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/DummyController.java
@@ -1,17 +1,30 @@
 package com.tdd.backend.user;
 
+import java.net.URI;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tdd.backend.auth.LoginUser;
+import com.tdd.backend.user.data.UserCreate;
+import com.tdd.backend.user.data.UserLogin;
 import com.tdd.backend.user.data.UserSession;
 
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 public class DummyController {
+
+	private final UserService userService;
+
 	@Operation(summary = "CORS 테스트를 위한 더미 API", description = "인증 필요없이 접근 가능")
 	@GetMapping("/test")
 	public String test() {
@@ -25,5 +38,39 @@ public class DummyController {
 		User user = session.getUser();
 		log.info(">> user : {}", user.getUserName());
 		log.info(">> token : {}", session.getAccessToken());
+	}
+
+	@Operation(summary = "CORS 테스트를 위한 더미 API (쿠키 발급)", description = "쿠키를 테스트하기 위한 쿠키 발급 테스트")
+	@GetMapping("/test/cookie")
+	public ResponseEntity<ResponseCookie> testCookie() {
+		UserCreate dummyUser = UserCreate.builder()
+			.email("test@test.com")
+			.userPassword("password")
+			.userName("육식주의자")
+			.phoneNumber("01001010101")
+			.build();
+		userService.save(dummyUser);
+
+		UserLogin userLogin = UserLogin.builder()
+			.email("test@test.com")
+			.userPassword("password")
+			.build();
+		String token = userService.signIn(userLogin);
+
+		//cookie를 통한 권한 인증
+		ResponseCookie cookie = ResponseCookie.from("Session", token)
+			.domain("localhost") //추후 yml 파일에 개발환경마다 서비스 도메인 분리
+			.path("/")
+			.httpOnly(true)
+			.secure(false)
+			.maxAge(60 * 60)
+			.sameSite("Strict")
+			.build();
+
+		log.info(">> {}", token);
+		return ResponseEntity.status(HttpStatus.FOUND)
+			.location(URI.create("/"))
+			.header(HttpHeaders.SET_COOKIE, cookie.toString())
+			.build();
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/DummyController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/DummyController.java
@@ -1,0 +1,29 @@
+package com.tdd.backend.user;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tdd.backend.auth.LoginUser;
+import com.tdd.backend.user.data.UserSession;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+public class DummyController {
+	@Operation(summary = "CORS 테스트를 위한 더미 API", description = "인증 필요없이 접근 가능")
+	@GetMapping("/test")
+	public String test() {
+		return "hello world";
+	}
+
+	@Operation(summary = "CORS 테스트를 위한 더미 API (인증필요)", description = "인증이 요구되는 접근 (쿠키 필요)")
+	@GetMapping("/test/auth")
+	public void testAuth(@LoginUser UserSession session) {
+
+		User user = session.getUser();
+		log.info(">> user : {}", user.getUserName());
+		log.info(">> token : {}", session.getAccessToken());
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/SessionStorage.java
+++ b/back-end/src/main/java/com/tdd/backend/user/SessionStorage.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.tdd.backend.user.data.Session;
+import com.tdd.backend.user.exception.UnauthorizedException;
 
 /**
  * 세션 디비 역할을 위한 임시적인 세션스토리지 (인메모리)
@@ -28,7 +29,7 @@ public class SessionStorage {
 		if (isSession(key)) {
 			return sessionMap.get(key);
 		}
-		return null;
+		throw new UnauthorizedException();
 	}
 
 	public static void clean() {

--- a/back-end/src/main/java/com/tdd/backend/user/SessionStorage.java
+++ b/back-end/src/main/java/com/tdd/backend/user/SessionStorage.java
@@ -3,7 +3,7 @@ package com.tdd.backend.user;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.tdd.backend.user.data.Session;
+import com.tdd.backend.user.data.UserSession;
 import com.tdd.backend.user.exception.UnauthorizedException;
 
 /**
@@ -11,10 +11,10 @@ import com.tdd.backend.user.exception.UnauthorizedException;
  * 수정 반드시 필요
  */
 public class SessionStorage {
-	private static final Map<String, Session> sessionMap = new ConcurrentHashMap<>();
+	private static final Map<String, UserSession> sessionMap = new ConcurrentHashMap<>();
 
-	public static void addSession(Session session) {
-		sessionMap.put(session.getAccessToken(), session);
+	public static void addSession(UserSession userSession) {
+		sessionMap.put(userSession.getAccessToken(), userSession);
 	}
 
 	public static int getCount() {
@@ -25,7 +25,7 @@ public class SessionStorage {
 		return sessionMap.containsKey(key);
 	}
 
-	public static Session getSession(String key) {
+	public static UserSession getSession(String key) {
 		if (isSession(key)) {
 			return sessionMap.get(key);
 		}

--- a/back-end/src/main/java/com/tdd/backend/user/SessionStorage.java
+++ b/back-end/src/main/java/com/tdd/backend/user/SessionStorage.java
@@ -1,0 +1,37 @@
+package com.tdd.backend.user;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.tdd.backend.user.data.Session;
+
+/**
+ * 세션 디비 역할을 위한 임시적인 세션스토리지 (인메모리)
+ * 수정 반드시 필요
+ */
+public class SessionStorage {
+	private static final Map<String, Session> sessionMap = new ConcurrentHashMap<>();
+
+	public static void addSession(Session session) {
+		sessionMap.put(session.getAccessToken(), session);
+	}
+
+	public static int getCount() {
+		return sessionMap.size();
+	}
+
+	public static boolean isSession(String key) {
+		return sessionMap.containsKey(key);
+	}
+
+	public static Session getSession(String key) {
+		if (isSession(key)) {
+			return sessionMap.get(key);
+		}
+		return null;
+	}
+
+	public static void clean() {
+		sessionMap.clear();
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/User.java
+++ b/back-end/src/main/java/com/tdd/backend/user/User.java
@@ -7,6 +7,7 @@ import org.springframework.data.relational.core.mapping.Table;
 import com.tdd.backend.post.Appointment;
 import com.tdd.backend.user.data.UserCreate;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Table("users")
@@ -24,8 +25,8 @@ public class User {
 
 	@Column("tester_id")
 	private Appointment appointment;
-
-	public User(String email, String userName, String phoneNumber, String userPassword) {
+	@Builder
+	private User(String email, String userName, String phoneNumber, String userPassword) {
 		this.email = email;
 		this.userName = userName;
 		this.phoneNumber = phoneNumber;

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -2,7 +2,8 @@ package com.tdd.backend.user;
 
 import java.net.URI;
 
-import javax.servlet.http.HttpSession;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpHeaders;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tdd.backend.user.data.UserCreate;
@@ -43,7 +45,6 @@ public class UserController {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setLocation(URI.create("/"));
 		return new ResponseEntity<>(headers, HttpStatus.FOUND);
-
 	}
 
 	@GetMapping("/users/validation/{email}}")
@@ -54,8 +55,22 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
-	public void login(@RequestBody @Valid UserLogin userLogin, HttpSession httpSession) {
-		String username = userService.signIn(userLogin);
-		httpSession.setAttribute("username", username);
+	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin, HttpServletResponse response) {
+		String accessToken = userService.signIn(userLogin);
+
+		Cookie cookie = new Cookie("Access-Token", accessToken);
+		cookie.setMaxAge(60 * 60);
+		cookie.setPath("/");
+		// add cookie to response
+		response.addCookie(cookie);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(URI.create("/"));
+		return new ResponseEntity<>(headers, HttpStatus.FOUND);
+	}
+
+	@RequestMapping("/test")
+	public void test() {
+
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -2,7 +2,6 @@ package com.tdd.backend.user;
 
 import java.net.URI;
 
-import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpHeaders;
@@ -23,8 +22,6 @@ import com.tdd.backend.user.data.UserSession;
 import com.tdd.backend.user.exception.DuplicateEmailException;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,13 +32,6 @@ public class UserController {
 	private final UserService userService;
 
 	@Operation(summary = "유저 회원가입 요청", description = "User SignUp request")
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "OK"),
-		@ApiResponse(responseCode = "302", description = "REDIRECT"),
-		@ApiResponse(responseCode = "400", description = "BAD REQUEST"),
-		@ApiResponse(responseCode = "404", description = "NOT FOUND"),
-		@ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
-	})
 	@PostMapping("/users")
 	public ResponseEntity<Void> signup(@RequestBody @Valid UserCreate userCreate) {
 		userService.save(userCreate);
@@ -58,8 +48,9 @@ public class UserController {
 		}
 	}
 
+	@Operation(summary = "유저 로그인 요청", description = "User Login request")
 	@PostMapping("/login")
-	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin, HttpSession httpSession) {
+	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin) {
 		String accessToken = userService.signIn(userLogin);
 		//cookie를 통한 권한 인증
 		ResponseCookie cookie = ResponseCookie.from("Session", accessToken)
@@ -78,16 +69,16 @@ public class UserController {
 			.build();
 	}
 
-	@RequestMapping("/auth")
-	public void test(@LoginUser UserSession session) {
+	@RequestMapping("/test")
+	public String test() {
+		return "hello world";
+	}
+
+	@RequestMapping("/test/auth")
+	public void testAuth(@LoginUser UserSession session) {
 
 		User user = session.getUser();
 		log.info(">> user : {}", user.getUserName());
 		log.info(">> token : {}", session.getAccessToken());
-	}
-
-	@RequestMapping("/")
-	public void index() {
-
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -1,7 +1,11 @@
 package com.tdd.backend.user;
 
+import java.net.URI;
+
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,9 +13,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.tdd.backend.user.data.UserCreate;
+import com.tdd.backend.user.data.UserLogin;
 import com.tdd.backend.user.exception.DuplicateEmailException;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,9 +40,9 @@ public class UserController {
 	public ResponseEntity<Void> signup(@RequestBody @Valid UserCreate userCreate) {
 		userService.save(userCreate);
 
-		return ResponseEntity.status(HttpStatus.FOUND)
-			.location(ServletUriComponentsBuilder.fromCurrentRequest().path("/").build().toUri())
-			.build();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setLocation(URI.create("/"));
+		return new ResponseEntity<>(headers, HttpStatus.FOUND);
 
 	}
 
@@ -50,6 +54,8 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
-	public void login() {
+	public void login(@RequestBody @Valid UserLogin userLogin, HttpSession httpSession) {
+		String username = userService.signIn(userLogin);
+		httpSession.setAttribute("username", username);
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -12,13 +12,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tdd.backend.auth.LoginUser;
 import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
-import com.tdd.backend.user.data.UserSession;
 import com.tdd.backend.user.exception.DuplicateEmailException;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,20 +64,5 @@ public class UserController {
 			.location(URI.create("/"))
 			.header(HttpHeaders.SET_COOKIE, cookie.toString())
 			.build();
-	}
-
-	@Operation(summary = "CORS 테스트를 위한 더미 API", description = "인증 필요없이 접근 가능")
-	@RequestMapping("/test")
-	public String test() {
-		return "hello world";
-	}
-
-	@Operation(summary = "CORS 테스트를 위한 더미 API (인증필요)", description = "인증이 요구되는 접근 (쿠키 필요)")
-	@RequestMapping("/test/auth")
-	public void testAuth(@LoginUser UserSession session) {
-
-		User user = session.getUser();
-		log.info(">> user : {}", user.getUserName());
-		log.info(">> token : {}", session.getAccessToken());
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -69,11 +69,13 @@ public class UserController {
 			.build();
 	}
 
+	@Operation(summary = "CORS 테스트를 위한 더미 API", description = "인증 필요없이 접근 가능")
 	@RequestMapping("/test")
 	public String test() {
 		return "hello world";
 	}
 
+	@Operation(summary = "CORS 테스트를 위한 더미 API (인증필요)", description = "인증이 요구되는 접근 (쿠키 필요)")
 	@RequestMapping("/test/auth")
 	public void testAuth(@LoginUser UserSession session) {
 

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,9 +17,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tdd.backend.auth.LoginUser;
-import com.tdd.backend.user.data.Session;
 import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
+import com.tdd.backend.user.data.UserSession;
 import com.tdd.backend.user.exception.DuplicateEmailException;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,17 +61,33 @@ public class UserController {
 	@PostMapping("/login")
 	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin, HttpSession httpSession) {
 		String accessToken = userService.signIn(userLogin);
+		//cookie를 통한 권한 인증
+		ResponseCookie cookie = ResponseCookie.from("Session", accessToken)
+			.domain("localhost") //추후 yml 파일에 개발환경마다 서비스 도메인 분리
+			.path("/")
+			.httpOnly(true)
+			.secure(false)
+			.maxAge(60 * 60)
+			.sameSite("Strict")
+			.build();
 
-		httpSession.setAttribute("AccessToken", accessToken);
-		HttpHeaders headers = new HttpHeaders();
-		headers.setLocation(URI.create("/"));
-		return new ResponseEntity<>(headers, HttpStatus.FOUND);
+		log.info(">> response cookie : {}", cookie);
+		return ResponseEntity.status(HttpStatus.FOUND)
+			.location(URI.create("/"))
+			.header(HttpHeaders.SET_COOKIE, cookie.toString())
+			.build();
 	}
 
 	@RequestMapping("/auth")
-	public void test(@LoginUser Session session) {
+	public void test(@LoginUser UserSession session) {
 
 		User user = session.getUser();
 		log.info(">> user : {}", user.getUserName());
+		log.info(">> token : {}", session.getAccessToken());
+	}
+
+	@RequestMapping("/")
+	public void index() {
+
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -2,8 +2,7 @@ package com.tdd.backend.user;
 
 import java.net.URI;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpHeaders;
@@ -16,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tdd.backend.auth.LoginUser;
+import com.tdd.backend.user.data.Session;
 import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
 import com.tdd.backend.user.exception.DuplicateEmailException;
@@ -24,7 +25,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class UserController {
@@ -55,22 +58,19 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
-	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin, HttpServletResponse response) {
+	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin, HttpSession httpSession) {
 		String accessToken = userService.signIn(userLogin);
 
-		Cookie cookie = new Cookie("Access-Token", accessToken);
-		cookie.setMaxAge(60 * 60);
-		cookie.setPath("/");
-		// add cookie to response
-		response.addCookie(cookie);
-
+		httpSession.setAttribute("AccessToken", accessToken);
 		HttpHeaders headers = new HttpHeaders();
 		headers.setLocation(URI.create("/"));
 		return new ResponseEntity<>(headers, HttpStatus.FOUND);
 	}
 
-	@RequestMapping("/test")
-	public void test() {
+	@RequestMapping("/auth")
+	public void test(@LoginUser Session session) {
 
+		User user = session.getUser();
+		log.info(">> user : {}", user.getUserName());
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserService.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserService.java
@@ -8,14 +8,13 @@ import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
 import com.tdd.backend.user.exception.UserNotFoundException;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
 	private final UserRepository userRepository;
-
-	public UserService(UserRepository userRepository) {
-		this.userRepository = userRepository;
-	}
 
 	public void save(UserCreate userCreate) {
 		userRepository.save(User.createUser(userCreate));

--- a/back-end/src/main/java/com/tdd/backend/user/UserService.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserService.java
@@ -4,9 +4,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import com.tdd.backend.user.data.Session;
 import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
+import com.tdd.backend.user.data.UserSession;
 import com.tdd.backend.user.exception.UserNotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -32,11 +32,11 @@ public class UserService {
 			throw new UserNotFoundException();
 		}
 		//todo : 암호화 적용, 세션 암호화
-		Session session = Session.builder()
+		UserSession userSession = UserSession.builder()
 			.user(optionalUser.get())
 			.build();
 
-		SessionStorage.addSession(session);
-		return session.getAccessToken();
+		SessionStorage.addSession(userSession);
+		return userSession.getAccessToken();
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserService.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserService.java
@@ -1,8 +1,12 @@
 package com.tdd.backend.user;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import com.tdd.backend.user.data.UserCreate;
+import com.tdd.backend.user.data.UserLogin;
+import com.tdd.backend.user.exception.UserNotFoundException;
 
 @Service
 public class UserService {
@@ -21,4 +25,13 @@ public class UserService {
 		return userRepository.countByEmail(email) > 0;
 	}
 
+	public String signIn(UserLogin userLogin) {
+		Optional<User> optionalUser = userRepository.findByEmail(userLogin.getEmail());
+
+		if (optionalUser.isEmpty() || !userLogin.getUserPassword().equals(optionalUser.get().getUserPassword())) {
+			throw new UserNotFoundException();
+		}
+		//todo : 암호화 적용, 세션 암호화
+		return optionalUser.get().getUserName();
+	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/UserService.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserService.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.tdd.backend.user.data.Session;
 import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
 import com.tdd.backend.user.exception.UserNotFoundException;
@@ -31,6 +32,11 @@ public class UserService {
 			throw new UserNotFoundException();
 		}
 		//todo : 암호화 적용, 세션 암호화
-		return optionalUser.get().getUserName();
+		Session session = Session.builder()
+			.user(optionalUser.get())
+			.build();
+
+		SessionStorage.addSession(session);
+		return session.getAccessToken();
 	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/data/Session.java
+++ b/back-end/src/main/java/com/tdd/backend/user/data/Session.java
@@ -1,0 +1,20 @@
+package com.tdd.backend.user.data;
+
+import java.util.UUID;
+
+import com.tdd.backend.user.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Session {
+	private final String accessToken;
+
+	private final User user;
+	@Builder
+	private Session(User user) {
+		this.accessToken = UUID.randomUUID().toString();
+		this.user = user;
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/data/SessionResponse.java
+++ b/back-end/src/main/java/com/tdd/backend/user/data/SessionResponse.java
@@ -1,0 +1,12 @@
+package com.tdd.backend.user.data;
+
+import lombok.Getter;
+
+@Getter
+public class SessionResponse {
+	private final String accessToken;
+
+	public SessionResponse(String accessToken) {
+		this.accessToken = accessToken;
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/data/UserCreate.java
+++ b/back-end/src/main/java/com/tdd/backend/user/data/UserCreate.java
@@ -4,11 +4,8 @@ import javax.validation.constraints.NotBlank;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@Builder
-@RequiredArgsConstructor
 public class UserCreate {
 	@NotBlank(message = "email 값은 필수입니다.")
 	private final String email;
@@ -21,4 +18,12 @@ public class UserCreate {
 
 	@NotBlank(message = "phoneNumber 값은 필수입니다.")
 	private final String phoneNumber;
+
+	@Builder
+	private UserCreate(String email, String userPassword, String userName, String phoneNumber) {
+		this.email = email;
+		this.userPassword = userPassword;
+		this.userName = userName;
+		this.phoneNumber = phoneNumber;
+	}
 }

--- a/back-end/src/main/java/com/tdd/backend/user/data/UserLogin.java
+++ b/back-end/src/main/java/com/tdd/backend/user/data/UserLogin.java
@@ -1,0 +1,20 @@
+package com.tdd.backend.user.data;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserLogin {
+	@NotBlank
+	private final String email;
+	@NotBlank
+	private final String userPassword;
+
+	@Builder
+	private UserLogin(String email, String userPassword) {
+		this.email = email;
+		this.userPassword = userPassword;
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/data/UserSession.java
+++ b/back-end/src/main/java/com/tdd/backend/user/data/UserSession.java
@@ -8,12 +8,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class Session {
+public class UserSession {
 	private final String accessToken;
 
 	private final User user;
 	@Builder
-	private Session(User user) {
+	private UserSession(User user) {
 		this.accessToken = UUID.randomUUID().toString();
 		this.user = user;
 	}

--- a/back-end/src/main/java/com/tdd/backend/user/exception/UnauthorizedException.java
+++ b/back-end/src/main/java/com/tdd/backend/user/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.tdd.backend.user.exception;
+
+public class UnauthorizedException extends RuntimeException {
+	private static final String MESSAGE = "인증되지 않은 접근입니다.";
+
+	public UnauthorizedException() {
+		super(MESSAGE);
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/user/exception/UserNotFoundException.java
+++ b/back-end/src/main/java/com/tdd/backend/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.tdd.backend.user.exception;
+
+public class UserNotFoundException extends RuntimeException {
+	private static final String MESSAGE = "해당하는 유저가 없습니다.";
+
+	public UserNotFoundException() {
+		super(MESSAGE);
+	}
+}

--- a/back-end/src/test/http/user.http
+++ b/back-end/src/test/http/user.http
@@ -8,3 +8,17 @@ Content-Type: application/json
   "userName" : "tester",
   "phoneNumber" : "010-1234-1234"
 }
+
+### 로그인
+POST http://localhost:8080/login
+Content-Type: application/json
+
+{
+  "email" : "test@test.com",
+  "userPassword" : "비밀번호"
+}
+
+### auth
+GET http://localhost:8080/auth
+Content-Type: application/json
+Cookie: SESSION=4583336a-fd6c-4ed1-b47e-d110c990fbb1

--- a/back-end/src/test/java/com/tdd/backend/post/PostServiceTest.java
+++ b/back-end/src/test/java/com/tdd/backend/post/PostServiceTest.java
@@ -30,8 +30,13 @@ class PostServiceTest {
 	@Test
 	void save_with_option_location_appointment() throws Exception {
 
-		User user = new User("hado@naver.com", "young",
-			"01012341234", "glory");
+		User user = User.builder()
+			.email("test@test.com")
+			.userName("tester")
+			.userPassword("pwd")
+			.phoneNumber("101010")
+			.build();
+
 		userRepository.save(user);
 
 		Set<Option> options = new HashSet<>();

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tdd.backend.user.data.UserCreate;
+import com.tdd.backend.user.data.UserLogin;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -106,5 +107,53 @@ class UserControllerTest {
 			.andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.toString()))
 			.andExpect(jsonPath("$.errorMessage").value("중복된 이메일입니다."))
 			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("유저 로그인_성공")
+	void login() throws Exception {
+	    //given
+		userRepository.save(User.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.userName("tester")
+			.phoneNumber("010101")
+			.build()
+		);
+
+		//when
+		UserLogin userLogin = UserLogin.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.build();
+
+		String loginRequestBody = objectMapper.writeValueAsString(userLogin);
+		mockMvc.perform(post("/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginRequestBody))
+			.andExpect(status().isOk())
+			.andDo(print());
+
+	    //then
+
+	}
+
+	@Test
+	@DisplayName("유저 로그인_실패")
+	void login_failed() throws Exception {
+		//when
+		UserLogin userLogin = UserLogin.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.build();
+
+		String loginRequestBody = objectMapper.writeValueAsString(userLogin);
+		mockMvc.perform(post("/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginRequestBody))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.errorMessage").value("해당하는 유저가 없습니다."))
+			.andDo(print());
+
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -127,7 +127,6 @@ class UserControllerTest {
 			.email("test@test.com")
 			.userPassword("pwd")
 			.build();
-
 		String loginRequestBody = objectMapper.writeValueAsString(userLogin);
 
 		//then
@@ -156,5 +155,23 @@ class UserControllerTest {
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.errorMessage").value("해당하는 유저가 없습니다."))
 			.andDo(print());
+	}
+	
+	@Test
+	@DisplayName("유저 로그인 권한 존재")
+	void auth_user() throws Exception {
+	    //given
+		userRepository.save(User.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.userName("tester")
+			.phoneNumber("010101")
+			.build()
+		);
+
+
+	    
+	    //then
+	    
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -156,22 +156,4 @@ class UserControllerTest {
 			.andExpect(jsonPath("$.errorMessage").value("해당하는 유저가 없습니다."))
 			.andDo(print());
 	}
-	
-	@Test
-	@DisplayName("유저 로그인 권한 존재")
-	void auth_user() throws Exception {
-	    //given
-		userRepository.save(User.builder()
-			.email("test@test.com")
-			.userPassword("pwd")
-			.userName("tester")
-			.phoneNumber("010101")
-			.build()
-		);
-
-
-	    
-	    //then
-	    
-	}
 }

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -91,10 +91,16 @@ class UserControllerTest {
 	@DisplayName("유저 회원가입_중복 이메일 들어옴.")
 	void signup_duplicate_email() throws Exception {
 		//given
-		userRepository.save(new User("test@tdd.com", "tester", "0101010", "pass"));
+		User user = User.builder()
+			.email("test@test.com")
+			.userName("tester")
+			.userPassword("pwd")
+			.phoneNumber("101010")
+			.build();
+		userRepository.save(user);
 
 		//when
-		mockMvc.perform(get("/users/validation/{email}}", "test@tdd.com")
+		mockMvc.perform(get("/users/validation/{email}}", user.getEmail())
 				.contentType(MediaType.TEXT_HTML))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.toString()))

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -128,14 +129,15 @@ class UserControllerTest {
 			.build();
 
 		String loginRequestBody = objectMapper.writeValueAsString(userLogin);
+
+		//then
 		mockMvc.perform(post("/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody))
-			.andExpect(status().isOk())
+			.andExpect(status().isFound())
 			.andDo(print());
 
-	    //then
-
+		Assertions.assertThat(SessionStorage.getCount()).isEqualTo(1);
 	}
 
 	@Test
@@ -154,6 +156,5 @@ class UserControllerTest {
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.errorMessage").value("해당하는 유저가 없습니다."))
 			.andDo(print());
-
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.tdd.backend.user;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +11,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tdd.backend.user.data.UserCreate;
+import com.tdd.backend.user.data.UserLogin;
+import com.tdd.backend.user.exception.UserNotFoundException;
 
 @SpringBootTest
 @Transactional
@@ -41,5 +45,42 @@ class UserServiceTest {
 
 		//then
 		Assertions.assertThat(userRepository.count()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("유저 로그인_성공")
+	void login() throws Exception {
+	    //given
+		User user = User.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.userName("tester")
+			.phoneNumber("01010")
+			.build();
+		userRepository.save(user);
+
+	    //when
+		UserLogin userLogin = UserLogin.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.build();
+
+		String userName = userService.signIn(userLogin);
+
+		//then
+		Assertions.assertThat(userName).isEqualTo(user.getUserName());
+	}
+
+	@Test
+	@DisplayName("유저 로그인_실패")
+	void login_failed() throws Exception {
+		//when
+		UserLogin userLogin = UserLogin.builder()
+			.email("test@test.com")
+			.userPassword("pwd")
+			.build();
+
+		//expected
+		assertThrows(UserNotFoundException.class, () -> userService.signIn(userLogin));
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
@@ -1,8 +1,8 @@
 package com.tdd.backend.user;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +27,7 @@ class UserServiceTest {
 	@BeforeEach
 	void setup() {
 		userRepository.deleteAll();
+		SessionStorage.clean();
 	}
 
 	@Test
@@ -44,7 +45,7 @@ class UserServiceTest {
 		userService.save(userCreate);
 
 		//then
-		Assertions.assertThat(userRepository.count()).isEqualTo(1);
+		assertThat(userRepository.count()).isEqualTo(1);
 	}
 
 	@Test
@@ -59,16 +60,17 @@ class UserServiceTest {
 			.build();
 		userRepository.save(user);
 
-	    //when
+		//when
 		UserLogin userLogin = UserLogin.builder()
 			.email("test@test.com")
 			.userPassword("pwd")
 			.build();
 
-		String userName = userService.signIn(userLogin);
+		String accessToken = userService.signIn(userLogin);
 
 		//then
-		Assertions.assertThat(userName).isEqualTo(user.getUserName());
+		assertThat(SessionStorage.getCount()).isEqualTo(1);
+		assertThat(SessionStorage.isSession(accessToken)).isTrue();
 	}
 
 	@Test
@@ -82,5 +84,6 @@ class UserServiceTest {
 
 		//expected
 		assertThrows(UserNotFoundException.class, () -> userService.signIn(userLogin));
+		assertThat(SessionStorage.getCount()).isEqualTo(0);
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
@@ -69,8 +69,8 @@ class UserServiceTest {
 		String accessToken = userService.signIn(userLogin);
 
 		//then
-		assertThat(SessionStorage.getCount()).isEqualTo(1);
 		assertThat(SessionStorage.isSession(accessToken)).isTrue();
+		assertThat(SessionStorage.getSession(accessToken).getUser().getId()).isEqualTo(user.getId());
 	}
 
 	@Test


### PR DESCRIPTION
### 이슈 넘버
- resolved #58 

### 이런 작업을 했어요
- 쿠키 기반의 기본적인 로그인을 구현하였습니다.
- 로그인 시 HashMap 형태의 인메모리 SessionStorage에 값이 저장되고 쿠키를 구워줍니다.
- CORS 설정과 이를 테스트하기 위한 더미 API를 임시적으로 생성하였습니다.

### 리뷰어는 여기에 집중해주시면 좋아요
### ❗[BE] 
- 로컬환경에서 서버 켜고 .http의 메서드를 회원가입 -> 로그인 -> 인증페이지 접근 순서로 진행하시면 되고, 인증페이지 접근 시에는 로그에 찍힌 랜덤하게 생성된 session id를 쿠키에 적어주셔야 정상적으로 작동합니다.
- 쿠키 기반 인증으로 구현된 코드의 문제점이나 이슈가 혹시 있을지 봐주시면 좋겠습니다.
- CORS 설정에 대해 정상적으로 작동되는지 검증해야 합니다.
### ❗ [FE] 
- http://52.78.106.53:8080/swagger-ui/index.html 로 접근하시면 현재 swagger API를 확인하실 수 있습니다.
- test와 관련된 API는 별도의 dummy controller에 추가해두었습니다.
- "/test" 는 인증이 필요없고 json 형식으로 "hello world"를 리턴합니다.
- "/test/auth"는 쿠키로 인증된 접근만 허용하며 별도의 응답은 없습니다.
- CORS  설정에 대해 정상적으로 작동되는지 검증해야 합니다.

### 향후 이런 계획이 있어요
- 로컬환경과 배포 환경을 다르게 설정하기 위한 파일 변수 등 yml 분리를 공부해야 할 듯 합니다.
- 더 나은 인증 방법으로 개선해볼 예정입니다.
