### PR TITLE
chore(#79) 백엔드 개발환경 분리, 도메인 주소를 파일변수로 설정

### DIFF
--- a/back-end/.gitignore
+++ b/back-end/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 ### IntelliJ IDEA ###
 src/main/resources/application.yml
+src/main/resources/application-prd.yml
 .idea
 *.iws
 *.iml

--- a/back-end/.gitignore
+++ b/back-end/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 ### IntelliJ IDEA ###
 src/main/resources/application.yml
+src/main/resources/application-dev.yml
 src/main/resources/application-prd.yml
 .idea
 *.iws

--- a/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
+++ b/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
@@ -2,6 +2,7 @@ package com.tdd.backend.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -12,10 +13,13 @@ import com.tdd.backend.auth.AuthResolver;
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
+	@Value("${domain.address}")
+	private String domainAddress; //개발환경에 따른 도메인 주소를 yml에 파일변수로 세팅
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("*")
+			.allowedOrigins(domainAddress)
 			.allowedMethods("*")
 			.maxAge(3000);
 	}

--- a/back-end/src/main/java/com/tdd/backend/exception/ExceptionController.java
+++ b/back-end/src/main/java/com/tdd/backend/exception/ExceptionController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.tdd.backend.user.exception.DuplicateEmailException;
+import com.tdd.backend.user.exception.UnauthorizedException;
 import com.tdd.backend.user.exception.UserNotFoundException;
 
 @RestControllerAdvice
@@ -45,6 +46,16 @@ public class ExceptionController {
 	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	@ExceptionHandler(UserNotFoundException.class)
 	public ErrorResponse userNotFoundExceptionHandler(UserNotFoundException ex) {
+		return ErrorResponse.builder()
+			.code(HttpStatus.UNAUTHORIZED.toString())
+			.errorMessage(ex.getMessage())
+			.build();
+
+	}
+
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	@ExceptionHandler(UnauthorizedException.class)
+	public ErrorResponse unauthorizedExceptionHandler(UnauthorizedException ex) {
 		return ErrorResponse.builder()
 			.code(HttpStatus.UNAUTHORIZED.toString())
 			.errorMessage(ex.getMessage())

--- a/back-end/src/main/java/com/tdd/backend/user/DummyController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/DummyController.java
@@ -1,6 +1,7 @@
 package com.tdd.backend.user;
 
 import java.net.URI;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -47,8 +48,9 @@ public class DummyController {
 	@Operation(summary = "CORS 테스트를 위한 더미 API (쿠키 발급)", description = "쿠키를 테스트하기 위한 쿠키 발급 테스트")
 	@GetMapping("/test/cookie")
 	public ResponseEntity<ResponseCookie> testCookie() {
+		String randomString = UUID.randomUUID().toString();
 		UserCreate dummyUser = UserCreate.builder()
-			.email("test@test.com")
+			.email(randomString)
 			.userPassword("password")
 			.userName("육식주의자")
 			.phoneNumber("01001010101")
@@ -56,7 +58,7 @@ public class DummyController {
 		userService.save(dummyUser);
 
 		UserLogin userLogin = UserLogin.builder()
-			.email("test@test.com")
+			.email(randomString)
 			.userPassword("password")
 			.build();
 		String token = userService.signIn(userLogin);

--- a/back-end/src/main/java/com/tdd/backend/user/DummyController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/DummyController.java
@@ -2,6 +2,7 @@ package com.tdd.backend.user;
 
 import java.net.URI;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -22,6 +23,9 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 public class DummyController {
+
+	@Value("${domain.address}")
+	private String domainAddress; //개발환경에 따른 도메인 주소를 yml에 파일변수로 세팅
 
 	private final UserService userService;
 
@@ -59,7 +63,7 @@ public class DummyController {
 
 		//cookie를 통한 권한 인증
 		ResponseCookie cookie = ResponseCookie.from("Session", token)
-			.domain("localhost") //추후 yml 파일에 개발환경마다 서비스 도메인 분리
+			.domain(domainAddress) //추후 yml 파일에 개발환경마다 서비스 도메인 분리
 			.path("/")
 			.httpOnly(true)
 			.secure(false)

--- a/back-end/src/main/java/com/tdd/backend/user/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/UserController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 import javax.validation.Valid;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -26,6 +27,10 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 public class UserController {
+
+	@Value("${domain.address}")
+	private String domainAddress; //개발환경에 따른 도메인 주소를 yml에 파일변수로 세팅
+
 	private final UserService userService;
 
 	@Operation(summary = "유저 회원가입 요청", description = "User SignUp request")
@@ -49,9 +54,10 @@ public class UserController {
 	@PostMapping("/login")
 	public ResponseEntity<Void> login(@RequestBody @Valid UserLogin userLogin) {
 		String accessToken = userService.signIn(userLogin);
-		//cookie를 통한 권한 인증
+
+		//todo: cookie를 통한 권한 인증, 다른 방식의 인증에 대해 리팩토링 여지 있음.
 		ResponseCookie cookie = ResponseCookie.from("Session", accessToken)
-			.domain("localhost") //추후 yml 파일에 개발환경마다 서비스 도메인 분리
+			.domain(domainAddress) //yml 파일에 개발환경마다 서비스 도메인 분리
 			.path("/")
 			.httpOnly(true)
 			.secure(false)

--- a/back-end/src/test/http/http-client.env.json
+++ b/back-end/src/test/http/http-client.env.json
@@ -1,0 +1,9 @@
+{
+  "dev": {
+    "domain-address": "localhost:8080"
+
+  },
+  "prd": {
+    "domain-address": "letsTdd.com"
+  }
+}

--- a/back-end/src/test/http/render.http
+++ b/back-end/src/test/http/render.http
@@ -1,8 +1,8 @@
 ### NEXO 옵션 렌더링
-GET http://localhost:8080/options/NEXO
+GET http://{{domain-address}}/options/NEXO
 
 ### AVANTE 옵션 렌더링
-GET http://localhost:8080/options/AVANTE
+GET http://{{domain-address}}/options/AVANTE
 
 
 

--- a/back-end/src/test/http/test.http
+++ b/back-end/src/test/http/test.http
@@ -1,0 +1,10 @@
+### test 접근
+GET http://{{domain-address}}/test
+
+### CORS 테스트를 위한 더미 API (쿠키 발급)
+GET http://{{domain-address}}/test/cookie
+
+### test auth
+GET http://{{domain-address}}/test/auth
+Content-Type: application/json
+Cookie: SESSION=9d6c8382-75eb-46be-afe9-792b6687a862

--- a/back-end/src/test/http/user.http
+++ b/back-end/src/test/http/user.http
@@ -1,5 +1,5 @@
 ### 회원가입
-POST http://localhost:8080/users
+POST http://{{domain-address}}/users
 Content-Type: application/json
 
 {
@@ -10,15 +10,10 @@ Content-Type: application/json
 }
 
 ### 로그인
-POST http://localhost:8080/login
+POST http://{{domain-address}}/login
 Content-Type: application/json
 
 {
   "email" : "test@test.com",
   "userPassword" : "비밀번호"
 }
-
-### auth
-GET http://localhost:8080/test/auth
-Content-Type: application/json
-Cookie: SESSION=1e4bb107-66e2-4ee1-9245-4ce87eabbaa5

--- a/back-end/src/test/http/user.http
+++ b/back-end/src/test/http/user.http
@@ -19,6 +19,6 @@ Content-Type: application/json
 }
 
 ### auth
-GET http://localhost:8080/auth
+GET http://localhost:8080/test/auth
 Content-Type: application/json
-Cookie: SESSION=4583336a-fd6c-4ed1-b47e-d110c990fbb1
+Cookie: SESSION=1e4bb107-66e2-4ee1-9245-4ce87eabbaa5


### PR DESCRIPTION
### 이슈 넘버
- resolved #79 

### 이런 이유로 코드를 변경했어요
- CORS 관련하여 도메인 주소가 로컬 환경과 배포환경에서 달라야 했습니다.

### 이런 작업을 했어요
- yml파일을 dev와 prd 환경으로 분리하였고 도메인 주소를 파일 변수로 관리하도록 하였습니다.
- WebMvcConfig에서 CORS의 allowOrigin을 해당 파일 변수로 설정해주었습니다.
- 더미 컨트롤러에도 동일한 환경으로 세팅하여 배포환경에서 프론트에서도 테스트할 수 있게 하였습니다.
- 누락되었던 401 Unauthorized 예외에 대한 exception handling을 처리하였습니다.

### 리뷰어는 여기에 집중해주시면 좋아요
- yml 파일을 통해 환경 분리하는 방법으로 앞으로 개발 과정에서 분리가 필요한 부분이 있다면 이 방식으로 추가하시면 좋을 듯합니다.
- API를 테스트하는 .http 도 개발환경에 따라 분리하였습니다. 변수 설정이 필요하다면 아래처럼 json에 추가해주시면 될 것 같습니다.
```json
{
  "dev": {
    "domain-address": "localhost:8080"

  },
  "prd": {
    "domain-address": "letsTdd.com"
  }
}
```

### 이런 위험이나 장애가 있어요
- 이러한 조치에도 CORS 해결이 안될 수도 있습니다. 테스트해보고 수정하도록 하겠습니다.

### 향후 이런 계획이 있어요
- 로그인 유지 완료하고, 비밀번호 암호화 설정도 해야 합니다.
