### PR TITLE
style(#103) 홈페이지 애니메이션 수정 및 추가

### DIFF
--- a/front-end/src/components/Home/Home.module.scss
+++ b/front-end/src/components/Home/Home.module.scss
@@ -204,3 +204,43 @@ $font100: 100px;
 .darkblue {
   color: $darkblue;
 }
+
+.animation-group {
+  [data-animation] {
+    opacity: 0;
+    &.animate {
+      opacity: 1;
+    }
+    &:nth-child(1) {
+      animation-delay: 300ms;
+    }
+    &:nth-child(2) {
+      animation-delay: 500ms;
+    }
+  }
+}
+
+.animated {
+  animation-duration: 1s;
+  animation-duration: 1.5s;
+  animation-fill-mode: both;
+}
+
+@keyframes fadeInLeft {
+  0% {
+    opacity: 0;
+    -webkit-transform: translate3d(-20%, 0, 0);
+    transform: translate3d(-20%, 0, 0);
+  }
+
+  to {
+    opacity: 1;
+    -webkit-transform: translateZ(0);
+    transform: translateZ(0);
+  }
+}
+
+.fadeInLeft {
+  -webkit-animation-name: fadeInLeft;
+  animation-name: fadeInLeft;
+}

--- a/front-end/src/components/Home/Home.ts
+++ b/front-end/src/components/Home/Home.ts
@@ -15,7 +15,9 @@ export class Home extends Component {
           if (entry.isIntersecting) {
             const target = entry.target as HTMLDivElement;
             target.style.opacity = "1";
-            observer.unobserve(target);
+          } else {
+            const target = entry.target as HTMLDivElement;
+            target.style.opacity = "0";
           }
         });
       }
@@ -24,5 +26,25 @@ export class Home extends Component {
     indexes.forEach((indexWrapper) => {
       observer.observe(indexWrapper);
     });
+
+    const fadeInObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const animation = entry.target.getAttribute("data-animation") as string;
+        if (entry.isIntersecting) {
+          entry.target.classList.add(
+            `${styles["animated"]}`,
+            `${styles[animation]}`
+          );
+        } else {
+          entry.target.classList.remove(
+            `${styles["animated"]}`,
+            `${styles[animation]}`
+          );
+        }
+      });
+    });
+
+    const animatedEls = qsa("[data-animation]");
+    animatedEls.forEach((el) => fadeInObserver.observe(el));
   }
 }

--- a/front-end/src/components/Home/template.ts
+++ b/front-end/src/components/Home/template.ts
@@ -1,81 +1,81 @@
-import styles from './Home.module.scss';
+import styles from "./Home.module.scss";
 export const homeTemplate = (): string => {
   return `
-    <div class=${styles['main-wrapper']}>
-      <div class="${styles['index-1']} ${styles['idxes']}" id="index">
-        <div class="${styles['flex-box']}">
-          <div class="${styles['helper-first']}"></div>
-          <div class="${styles['first-top-wrapper']}">
-            <span class="${styles['first-title']}">TDD</span>
+    <div class="${styles["main-wrapper"]} ${styles["animation-group"]}">
+      <div class="${styles["index-1"]} ${styles["idxes"]}" id="index">
+        <div class="${styles["flex-box"]}">
+          <div class="${styles["helper-first"]}"></div>
+          <div class="${styles["first-top-wrapper"]}">
+            <span class="${styles["first-title"]}">TDD</span>
           </div>
         </div>
-        <div class="${styles['mid-wrapper']} ${styles['flex-box']}">
-          <div class="${styles['helper-second']}"></div>
-          <span class="${styles['second-title']}">티디디</span>
+        <div class="${styles["mid-wrapper"]} ${styles["flex-box"]}">
+          <div class="${styles["helper-second"]}"></div>
+          <span class="${styles["second-title"]}">티디디</span>
         </div>
-        <div class="${styles['last-wrapper']}">
-          <div class="${styles['flex-box']}">
-            <div class="${styles['helper-first']}"></div>
-            <div class="${styles['text-container']}">
-              <span class="${styles['third-title']}">Try</span> <br />
-              <span class="${styles['third-title']}">Drive</span> <br />
-              <span class="${styles['third-title']}">Delightly</span> 
+        <div class="${styles["last-wrapper"]}">
+          <div class="${styles["flex-box"]}">
+            <div class="${styles["helper-first"]}"></div>
+            <div class="${styles["text-container"]}">
+              <span class="${styles["third-title"]}">Try</span> <br />
+              <span class="${styles["third-title"]}">Drive</span> <br />
+              <span class="${styles["third-title"]}">Delightly</span> 
             </div>
           </div>
         </div>
       </div>
-      <div class="${styles['index-2']} ${styles['idxes']}" id="index">
-        <div class="${styles['empty-wrapper']}"></div>
-        <div class="${styles['second-top-wrapper']} ${styles['flex-box']}">
-          <div class="${styles['helper-first']}"></div>
-          <div class="${styles['second-first-text']}">
+      <div class="${styles["index-2"]} ${styles["idxes"]}" id="index">
+        <div class="${styles["empty-wrapper"]}"></div>
+        <div class="${styles["second-top-wrapper"]} ${styles["flex-box"]}">
+          <div class="${styles["helper-first"]}"></div>
+          <div class="${styles["second-first-text"]}">
             <span class="${styles.tossblue}">We make your </span><br />
             <span class="${styles.darkblue}">Experiences </span><br />
             <span class="${styles.tossblue}">special to others </span><br />
           </div>
         </div>
-        <div class="${styles['second-bottom-wrapper']} ${styles['flex-box']}">
-          <div class="${styles['helper-second']}"></div>
-          <div class="${styles['second-second-text']}">
-            <span class="${styles['tossblue']}">Through </span>
+        <div class="${styles["second-bottom-wrapper"]} ${styles["flex-box"]}">
+          <div class="${styles["helper-second"]}"></div>
+          <div class="${styles["second-second-text"]}">
+            <span class="${styles["tossblue"]}">Through </span>
             <span class="${styles.darkblue}">Sharing </span>
           </div>
         </div>
       </div>
-      <div class="${styles['index-3']} ${styles['idxes']}" id="index">
-        <div class="${styles['empty-wrapper']}"></div>
-        <div class="${styles['third-top-wrapper']}">
-          <div class="${styles['third-top-text']}">
+      <div class="${styles["index-3"]} ${styles["idxes"]}" id="index">
+        <div class="${styles["empty-wrapper"]}"></div>
+        <div class="${styles["third-top-wrapper"]}">
+          <div class="${styles["third-top-text"]}>
             우리는 더 나은 <b class="${styles.darkblue}">사용자 경험</b>을 위해
             <br />
             끊임없이 고민하며 지속 발전을 추구합니다.
           </div>
         </div>
-        <div class="${styles['third-bottom-wrapper']}">
-          <img class="${styles['car-image']}" src="${
+        <div class="${styles["third-bottom-wrapper"]}">
+          <img class="${styles["car-image"]}" src="${
     process.env.VITE_IMAGE_URL
   }/share.png"></img>
-          <div class="${styles['third-bottom-text']}">
+          <div class="${styles["third-bottom-text"]}">
             <b class="${styles.darkblue}">당신의 경험</b>이
             <b class="${styles.tossblue}">타인의 경험</b>으로
           </div>
         </div>
       </div>
-      <div class="${styles['index-4']} ${styles['idxes']}" id="index">
-        <div class="${styles['fourth-top-wrapper']}">
-          <div class="${styles['fourth-top-text']} ${styles.tossblue}">
+      <div class="${styles["index-4"]} ${styles["idxes"]}" id="index">
+        <div class="${styles["fourth-top-wrapper"]}">
+          <div class="${styles["fourth-top-text"]} ${styles.tossblue}">
             Try <br />
             Drive <br />
             Delightly
           </div>
         </div>
-        <div class="${styles['fourth-bottom-wrapper']}">
-          <div class="${['fourth-mid-text']}">
+        <div class="${styles["fourth-bottom-wrapper"]}">
+          <div class="${["fourth-mid-text"]}">
             <span class="${styles.darkblue} ${styles.big}">티디디</span>
             <span>는 다음과 같은 아이디어에서
             출발했습니다.</span>
           </div>
-          <div class="${styles['fourth-bottom-text']}">
+          <div class="${styles["fourth-bottom-text"]}">
             현대자동차의 시승 사이트에 들어가면 시승 신청을 해볼 수 있습니다.
             하지만 아반떼의 경우 '드라이빙 라운지 강남'을 포함하여 전국 8개의
             라운지에서만 시승 신청을 할 수 있었습니다. 또한 드라이빙 라운지
@@ -86,27 +86,29 @@ export const homeTemplate = (): string => {
           </div>
         </div>
       </div>
-      <div class="${styles['index-5']} ${styles['idxes']}" id="index">
-        <div class="${styles['fifth-top-wrapper']} ${styles.tossblue}">
-          <div class="${styles['fifth-title-text']}">
-            지금 바로 <br />
-            경험 시작
+      <div class="${styles["index-5"]} ${styles["idxes"]}" id="index">
+        <div class="${styles["fifth-top-wrapper"]} ${styles.tossblue}">
+          <div class="${styles["fifth-title-text"]}">
+            <spsn>지금 바로</span> <br />
+            <span>경험 시작</span>
           </div>
         </div>
-        <div class="${styles['fifth-bottom-wrapper']}">
-          <a data-link href="/sharing" class="${styles['fifth-left-wrapper']}">
-            <img class="${styles['fifth-first-img']}" src="${
+        <div class="${styles["fifth-bottom-wrapper"]}">
+          <a data-link href="/sharing" class="${
+            styles["fifth-left-wrapper"]
+          }" data-animation="fadeInLeft">
+            <img class="${styles["fifth-first-img"]}" src="${
     process.env.VITE_IMAGE_URL
   }/sharing.png" />
-            <div class="${styles['fifth-texts']}">공유하기</div>
+            <div class="${styles["fifth-texts"]}">공유하기</div>
           </a>
           <a data-link href="/experiencing" class="${
-            styles['fifth-right-wrapper']
-          }">
-            <img class="${styles['fifth-second-img']}" src="${
+            styles["fifth-right-wrapper"]
+          }" data-animation="fadeInLeft">
+            <img class="${styles["fifth-second-img"]}" src="${
     process.env.VITE_IMAGE_URL
   }/use.png" />
-            <div class="${styles['fifth-texts']}">시승하기</div>
+            <div class="${styles["fifth-texts"]}">시승하기</div>
           </a>
         </div>
       </div>


### PR DESCRIPTION
### 이슈 넘버
- resolved #103 

### 이런 이유로 코드를 변경했어요
- 처음에 스크롤 하면 나타났던 애니메이션이 다시 실행되지 않았어요.
- 애니메이션이 더 있으면 좋을것 같았어요
### 이런 작업을 했어요
- 애니메이션이 실행 된 후 observer가 더이상 구독을 취소하지 않아요
- 마지막 시승, 공유 버튼에 fadeIn animation을 추가했어요
### 리뷰어는 여기에 집중해주시면 좋아요
- scss코드가 좀 많이 더러워요

### 이런 위험이나 장애가 있어요
- IntersectionObserver는 현재 보이는 ViewPort를 기준으로 해당 영역이 ViewPort에 있는지 검사해요. 스크롤을 내릴때는 상관없지만, 스크롤을 올릴때 footer 영역 및에(?)있는 영역은 ViewPort에 들어왔다고 판단하기 때문에 애니메이션이 의도하지 않은대로 미리 실행될 때가 있어요. 

### 향후 이런 계획이 있어요
- 애니메이션을 많이 참고해봤는데, 저번에 말씀해주신 text-animation (글자 하나하나 나타나는 것)을 넣어보고 싶었는데 마땅히 추가할 곳이 없었어요. 한번 이야기를 나누어 보았으면 좋겠어요.
- about page에는 좀 더 예쁜 애니메이션을 넣고 싶어요
### 스크린샷
![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/52685740/218266221-93160456-8939-433e-bf2f-cdd3d64e3902.gif)

