### PR TITLE
feature(#81): 슬라이더, 옵션셀렉터 스토어 연결

### DIFF
--- a/front-end/src/components/ImageSlider/ImageSlider.module.scss
+++ b/front-end/src/components/ImageSlider/ImageSlider.module.scss
@@ -21,6 +21,8 @@
   .slider {
     position: relative;
     overflow: hidden;
+    width: 940px;
+    height: 515px;
 
     img {
       position: absolute;

--- a/front-end/src/components/ImageSlider/ImageSlider.module.scss
+++ b/front-end/src/components/ImageSlider/ImageSlider.module.scss
@@ -1,5 +1,6 @@
 .wrapper {
   width: fit-content;
+  margin: 0 auto;
 }
 .slider-container {
   display: flex;

--- a/front-end/src/components/ImageSlider/ImageSlider.ts
+++ b/front-end/src/components/ImageSlider/ImageSlider.ts
@@ -8,7 +8,7 @@ import { OptionStore } from '@/store/OptionStore/OptionStore';
 export class ImageSlider extends Component {
   setup(): void {
     this.state.timer = null;
-    OptionStore.subscribe(this.render.bind(this));
+    OptionStore.subscribe(this.render.bind(this), this.constructor.name);
   }
   template(): string {
     const { props } = this;

--- a/front-end/src/components/ImageSlider/ImageSlider.ts
+++ b/front-end/src/components/ImageSlider/ImageSlider.ts
@@ -23,8 +23,8 @@ export class ImageSlider extends Component {
       if (idx > imgIdx) return 'left: 100%';
       return '';
     });
-    const leftBtnClass = this.isStartIdx() ? 'disabled' : '';
-    const rightBtnClass = this.isEndIdx() ? 'disabled' : '';
+    const leftBtnClass = this.isStartIdx() ? styles.disabled : '';
+    const rightBtnClass = this.isEndIdx() ? styles.disabled : '';
     return `
     <div class="${styles.wrapper}">
       <div class="${styles['slider-container']}">
@@ -50,9 +50,6 @@ export class ImageSlider extends Component {
     this.state.$images = Array.from(
       qsa('img', this.target)
     ) as HTMLImageElement[];
-
-    this.sliderSizeInit();
-    this.imageInit();
   }
 
   setEvent(): void {
@@ -98,34 +95,6 @@ export class ImageSlider extends Component {
         name: this.props.list[this.state.imgIdx].title,
       });
     }, 1000);
-  }
-
-  sliderSizeInit() {
-    const $slider = qs(`.${styles.slider}`, this.target) as HTMLDivElement;
-    if (this.props.width) {
-      $slider.style.width = this.props.width;
-      $slider.style.height = this.props.height;
-      return;
-    }
-    const img = new Image();
-    img.src = this.state.$images[0].src;
-    img.onload = function () {
-      $slider.style.width = img.width + 'px';
-      $slider.style.height = img.height + 'px';
-    };
-  }
-
-  imageInit() {
-    this.imageSizeInit();
-  }
-
-  imageSizeInit() {
-    const $images = qsa('img', this.target);
-    const imageArray = Array.from($images) as HTMLElement[];
-    imageArray.forEach((img) => {
-      img.style.width = this.props.sizeX + 'px';
-      img.style.height = this.props.sizeY + 'px';
-    });
   }
 
   isStartIdx() {

--- a/front-end/src/components/ImageSlider/ImageSlider.ts
+++ b/front-end/src/components/ImageSlider/ImageSlider.ts
@@ -8,7 +8,6 @@ import { OptionStore } from '@/store/OptionStore/OptionStore';
 export class ImageSlider extends Component {
   setup(): void {
     this.state.timer = null;
-    OptionStore.subscribe(this.render.bind(this), this.constructor.name);
   }
   template(): string {
     const { props } = this;

--- a/front-end/src/components/OptionForm/OptionForm.module.scss
+++ b/front-end/src/components/OptionForm/OptionForm.module.scss
@@ -44,7 +44,7 @@
   transition: all 0.5s ease;
 }
 
-.show {
+.close {
   max-height: 500px;
   padding: 14px 0;
   transform: translateY(0);

--- a/front-end/src/components/OptionForm/OptionForm.ts
+++ b/front-end/src/components/OptionForm/OptionForm.ts
@@ -124,7 +124,6 @@ export class OptionForm extends Component {
     <div class="${styles['form-container']}">
       ${data.map((ele) => this.categoryTemplate(ele)).join('')}
     </div>
-    <div>option:${options}</div>
     `;
   }
 
@@ -142,7 +141,10 @@ export class OptionForm extends Component {
   optionBtnTemplate({ category, name }: IOptions) {
     const isActive =
       OptionStore.getState().options.findIndex((ele: IOptions) => {
-        return ele.category === category && ele.name === name;
+        return (
+          ele.category.trim() === category.trim() &&
+          ele.name.trim() === name.trim()
+        );
       }) !== -1;
     const buttonClass = isActive ? styles['is-active'] : '';
     const buttonState = isActive ? 'active' : 'inactive';

--- a/front-end/src/components/OptionForm/OptionForm.ts
+++ b/front-end/src/components/OptionForm/OptionForm.ts
@@ -1,159 +1,185 @@
 import Component from '@/core/Component';
 import styles from './OptionForm.module.scss';
 import { OptionStore } from '@/store/OptionStore/OptionStore';
-const DUMMY_DATA = {
-  options: [
-    {
-      category: '차종',
-      option: [
-        '수소 / 전기차',
-        'N / N Line',
-        '승용',
-        'SUV',
-        'MPV',
-        '소형트럭&택시',
-        '트럭',
-        '버스',
-      ],
-    },
+const DUMMY_DATA = [
+  {
+    category: '차종',
+    options: [
+      { category: '차종', name: '수소 / 전기차' },
+      { category: '차종', name: 'N / N Line' },
+      { category: '차종', name: '승용' },
+      { category: '차종', name: 'SUV' },
+      { category: '차종', name: 'MPV' },
+      { category: '차종', name: '소형트럭&택시' },
+      { category: '차종', name: '트럭' },
+      { category: '차종', name: '버스' },
+    ],
+  },
 
-    {
-      category: '엔진',
-      option: ['디젤', '전기', '가솔린', '하이브리드', '수소', 'LPG'],
-    },
-    {
-      category: '안전/성능',
-      option: [
-        '주차 거리 경고-전방 ',
-        '주차 거리 경고-후방 ',
-        '진동경고 스티어링 휠 ',
-        '후륜 멀티링크 서스펜션 ',
-        '랙 구동형 전동식 파워스티어링(RMDPS) ',
-      ],
-    },
-    {
-      category: '지능형 안전기술',
-      option: [
-        '후측방 충돌방지 보조 ',
-        '안전 하차 보조 ',
-        '전방 충돌방지 보조 ',
-        '차로 이탈방지 보조 ',
-        '스마트 크루즈 컨트롤 ',
-        '원격 스마트 주차 보조 ',
-        '후석 승객 알림 ',
-      ],
-    },
-    {
-      category: '내장/외장',
-      option: [
-        'LED 헤드램프',
-        'LED 리어콤비램프 ',
-        '선루프',
-        '루프랙 ',
-        '프리미엄 타이어',
-        '클러스터(컬러 LCD)',
-        '전자식 변속버튼 ',
-        '열선 스티어링 휠 ',
-        '앰비언트 무드램프 ',
-      ],
-    },
-    {
-      category: '시트',
-      option: [
-        '동승석 통풍시트 ',
-        '2열 통풍시트 ',
-        '운전석 자세 메모리 시스템 ',
-        '동승석 릴렉션 컴포트 시트 ',
-        '운전석 파워시트 ',
-        '동승석 파워시트 ',
-        '동승석 워크인 스위치 ',
-        '운전석 통풍시트 ',
-        '뒷좌석 열선시트 ',
-        '앞좌석 열선시트 ',
-      ],
-    },
-    {
-      category: '편의',
-      option: [
-        '서라운드 뷰 모니터 ',
-        '후방모니터 ',
-        '후측방모니터 ',
-        '버튼시동 스마트키 시스템 ',
-        '하이패스 시스템 ',
-        '스마트폰 무선 충전 ',
-        '헤드업 디스플레이 ',
-        '전동식 트렁크',
-        '디지털 키 ',
-        '2열 커튼',
-        '듀얼 풀오토 에어컨 ',
-        '2열 에어벤트 ',
-      ],
-    },
-    {
-      category: '멀티미디어',
-      option: ['디스플레이 오디오 ', '내비게이션', '프리미엄 사운드 시스템 '],
-    },
-  ],
-};
+  {
+    category: '엔진',
+    options: [
+      { category: '엔진', name: '디젤' },
+      { category: '엔진', name: '전기' },
+      { category: '엔진', name: '가솔린' },
+      { category: '엔진', name: '하이브리드' },
+      { category: '엔진', name: '수소' },
+      { category: '엔진', name: 'LPG' },
+    ],
+  },
+  {
+    category: '안전/성능',
+    options: [
+      { category: '안전/성능', name: '주차 거리 경고-전방 ' },
+      { category: '안전/성능', name: '주차 거리 경고-후방 ' },
+      { category: '안전/성능', name: '진동경고 스티어링 휠 ' },
+      { category: '안전/성능', name: '후륜 멀티링크 서스펜션 ' },
+      { category: '안전/성능', name: '랙 구동형 전동식 파워스티어링(RMDPS) ' },
+    ],
+  },
+  {
+    category: '지능형 안전기술',
+    options: [
+      { category: '지능형 안전기술', name: '후측방 충돌방지 보조 ' },
+      { category: '지능형 안전기술', name: '안전 하차 보조 ' },
+      { category: '지능형 안전기술', name: '전방 충돌방지 보조 ' },
+      { category: '지능형 안전기술', name: '차로 이탈방지 보조 ' },
+      { category: '지능형 안전기술', name: '스마트 크루즈 컨트롤 ' },
+      { category: '지능형 안전기술', name: '원격 스마트 주차 보조 ' },
+      { category: '지능형 안전기술', name: '후석 승객 알림 ' },
+    ],
+  },
+  {
+    category: '내장/외장',
+    options: [
+      { category: '내장/외장', name: 'LED 헤드램프' },
+      { category: '내장/외장', name: 'LED 리어콤비램프 ' },
+      { category: '내장/외장', name: '선루프' },
+      { category: '내장/외장', name: '루프랙 ' },
+      { category: '내장/외장', name: '프리미엄 타이어' },
+      { category: '내장/외장', name: '클러스터(컬러 LCD)' },
+      { category: '내장/외장', name: '전자식 변속버튼 ' },
+      { category: '내장/외장', name: '열선 스티어링 휠 ' },
+      { category: '내장/외장', name: '앰비언트 무드램프 ' },
+    ],
+  },
+  {
+    category: '시트',
+    options: [
+      { category: '시트', name: '동승석 통풍시트 ' },
+      { category: '시트', name: '2열 통풍시트 ' },
+      { category: '시트', name: '운전석 자세 메모리 시스템 ' },
+      { category: '시트', name: '동승석 릴렉션 컴포트 시트 ' },
+      { category: '시트', name: '운전석 파워시트 ' },
+      { category: '시트', name: '동승석 파워시트 ' },
+      { category: '시트', name: '동승석 워크인 스위치 ' },
+      { category: '시트', name: '운전석 통풍시트 ' },
+      { category: '시트', name: '뒷좌석 열선시트 ' },
+      { category: '시트', name: '앞좌석 열선시트 ' },
+    ],
+  },
+  {
+    category: '편의',
+    options: [
+      { category: '편의', name: '서라운드 뷰 모니터 ' },
+      { category: '편의', name: '후방모니터 ' },
+      { category: '편의', name: '후측방모니터 ' },
+      { category: '편의', name: '버튼시동 스마트키 시스템 ' },
+      { category: '편의', name: '하이패스 시스템 ' },
+      { category: '편의', name: '스마트폰 무선 충전 ' },
+      { category: '편의', name: '헤드업 디스플레이 ' },
+      { category: '편의', name: '전동식 트렁크' },
+      { category: '편의', name: '디지털 키 ' },
+      { category: '편의', name: '2열 커튼' },
+      { category: '편의', name: '듀얼 풀오토 에어컨 ' },
+      { category: '편의', name: '2열 에어벤트 ' },
+    ],
+  },
+  {
+    category: '멀티미디어',
+    options: [
+      { category: '멀티미디어', name: '디스플레이 오디오 ' },
+      { category: '멀티미디어', name: '내비게이션' },
+      { category: '멀티미디어', name: '프리미엄 사운드 시스템 ' },
+    ],
+  },
+];
 interface ICategory {
   category: string;
-  option: string[];
+  options: IOptions[];
+}
+interface IOptions {
+  category: string;
+  name: string;
 }
 
 export class OptionForm extends Component {
+  setup(): void {
+    OptionStore.subscribe(this.render.bind(this), this.constructor.name);
+  }
   template(): string {
+    const options = JSON.stringify(OptionStore.getState().options);
     const data = DUMMY_DATA;
     return `
     <div class="${styles['form-container']}">
-      ${data.options.map((ele) => this.categoryTemplate(ele)).join('')}
+      ${data.map((ele) => this.categoryTemplate(ele)).join('')}
     </div>
+    <div>option:${options}</div>
     `;
   }
 
-  mounted(): void {
-    OptionStore.dispatch('OPTION_INIT');
-  }
-
-  categoryTemplate({ category, option }: ICategory) {
+  categoryTemplate({ category, options }: ICategory) {
     return `
     <div class="${styles.container}">
         <div class="${styles.container__title}">${category}</div>      
         <div class="${styles['filter-container']}">
-            ${option.map((option) => this.optionBtnTemplate(option)).join('')}
+            ${options.map((ele) => this.optionBtnTemplate(ele)).join('')}
         </div>
-    </div>
+    </div>    
     `;
   }
 
-  optionBtnTemplate(option: string) {
-    return `<button class="${styles['filter-button']}" data-state="inactive">${option}</button>`;
+  optionBtnTemplate({ category, name }: IOptions) {
+    const isActive =
+      OptionStore.getState().options.findIndex((ele: IOptions) => {
+        return ele.category === category && ele.name === name;
+      }) !== -1;
+    const buttonClass = isActive ? styles['is-active'] : '';
+    const buttonState = isActive ? 'active' : 'inactive';
+    return `<button class="${styles['filter-button']} ${buttonClass}" data-state="${buttonState}">${name}</button>`;
   }
 
   setEvent(): void {
     this.addEvent('click', `.${styles['filter-button']}`, ({ target }) => {
       const $button = target as HTMLButtonElement;
-      const $category = $button.parentElement
-        ?.previousElementSibling as HTMLDivElement;
       const buttonState = $button.getAttribute('data-state');
-
-      if (buttonState == 'inactive') {
-        $button.classList.add(styles['is-active']);
-        $button.setAttribute('data-state', 'active');
-        OptionStore.dispatch('ADD_CAR_OPTION', {
-          option: { name: $button.innerText, category: $category.innerText },
-        });
-      } else {
-        $button.classList.remove(styles['is-active']);
-        $button.setAttribute('data-state', 'inactive');
-        OptionStore.dispatch('DELETE_CAR_OPTION', {
-          option: { name: $button.innerText, category: $category.innerText },
-        });
-      }
+      if (buttonState === 'inactive') this.activeBtn($button);
+      if (buttonState === 'active') this.inactiveBtn($button);
     });
 
     this.addEvent('click', `.${styles.container__title}`, ({ target }) => {
       const $target = target as HTMLDivElement;
       $target.nextElementSibling?.classList.toggle(styles.show);
+    });
+  }
+
+  activeBtn($button: HTMLButtonElement) {
+    const $category = $button.parentElement
+      ?.previousElementSibling as HTMLDivElement;
+    $button.classList.add(styles['is-active']);
+    $button.setAttribute('data-state', 'active');
+    OptionStore.dispatch('ADD_CAR_OPTION', {
+      option: { name: $button.innerText, category: $category.innerText },
+    });
+  }
+
+  inactiveBtn($button: HTMLButtonElement) {
+    const $category = $button.parentElement
+      ?.previousElementSibling as HTMLDivElement;
+    $button.classList.remove(styles['is-active']);
+    $button.setAttribute('data-state', 'inactive');
+    OptionStore.dispatch('DELETE_CAR_OPTION', {
+      option: { name: $button.innerText, category: $category.innerText },
     });
   }
 }

--- a/front-end/src/components/OptionForm/OptionForm.ts
+++ b/front-end/src/components/OptionForm/OptionForm.ts
@@ -121,7 +121,6 @@ export class OptionForm extends Component {
     OptionStore.subscribe(this.render.bind(this), this.constructor.name);
   }
   template(): string {
-    const options = JSON.stringify(OptionStore.getState().options);
     const data = DUMMY_DATA;
     const openState = OptionStore.getState().openState;
     return `
@@ -130,7 +129,6 @@ export class OptionForm extends Component {
         .map((ele, idx) => this.categoryTemplate(ele, openState[idx]))
         .join('')}
     </div>
-    <div>option:${options}</div>
     `;
   }
 

--- a/front-end/src/components/OptionForm/OptionForm.ts
+++ b/front-end/src/components/OptionForm/OptionForm.ts
@@ -1,6 +1,7 @@
 import Component from '@/core/Component';
 import styles from './OptionForm.module.scss';
 import { OptionStore } from '@/store/OptionStore/OptionStore';
+import { qsa } from '@/utils/querySelector';
 const DUMMY_DATA = [
   {
     category: '차종',
@@ -166,22 +167,40 @@ export class OptionForm extends Component {
   }
 
   activeBtn($button: HTMLButtonElement) {
-    const $category = $button.parentElement
-      ?.previousElementSibling as HTMLDivElement;
     $button.classList.add(styles['is-active']);
     $button.setAttribute('data-state', 'active');
-    OptionStore.dispatch('ADD_CAR_OPTION', {
-      option: { name: $button.innerText, category: $category.innerText },
-    });
+    setTimeout(() => {
+      OptionStore.dispatch('UPDATE_CAR_OPTION', {
+        options: this.getActiveBtnProperty(),
+      });
+    }, 300);
   }
 
   inactiveBtn($button: HTMLButtonElement) {
-    const $category = $button.parentElement
-      ?.previousElementSibling as HTMLDivElement;
     $button.classList.remove(styles['is-active']);
     $button.setAttribute('data-state', 'inactive');
-    OptionStore.dispatch('DELETE_CAR_OPTION', {
-      option: { name: $button.innerText, category: $category.innerText },
+    setTimeout(() => {
+      OptionStore.dispatch('UPDATE_CAR_OPTION', {
+        options: this.getActiveBtnProperty(),
+      });
+    }, 300);
+  }
+
+  getActiveBtnProperty() {
+    const $activeButtons = this.getAllActiveBtn();
+    return $activeButtons.map(($button) => {
+      const $category = $button.parentElement
+        ?.previousElementSibling as HTMLDivElement;
+      return { name: $button.innerText, category: $category.innerText };
     });
+  }
+
+  getAllActiveBtn(): HTMLButtonElement[] {
+    const $buttons = qsa(`.${styles['filter-button']}`, this.target);
+    const $activeButtons = Array.from($buttons).filter(($button) => {
+      const buttonState = $button.getAttribute('data-state');
+      return buttonState === 'active';
+    });
+    return $activeButtons as HTMLButtonElement[];
   }
 }

--- a/front-end/src/constants/carList.ts
+++ b/front-end/src/constants/carList.ts
@@ -60,7 +60,7 @@ export const carList: ICar[] = [
     title: '아반떼',
   },
   {
-    fileName: '016_아반떼_Hybrid.png',
+    fileName: '016_avante_Hybrid.png',
     title: '아반떼 Hybrid',
   },
   {

--- a/front-end/src/core/Store.ts
+++ b/front-end/src/core/Store.ts
@@ -4,7 +4,7 @@ interface DynamicObject {
 
 export class Store {
   #state: DynamicObject;
-  #listeners: Function[] = [];
+  #listeners: DynamicObject = {};
   #reducer: Function;
 
   constructor(state: object, reducer: Function) {
@@ -16,12 +16,12 @@ export class Store {
     return { ...this.#state };
   }
 
-  subscribe(func: any) {
-    this.#listeners.push(func);
+  subscribe(func: Function, fnKey: string) {
+    this.#listeners[fnKey] = func;
   }
 
   publish() {
-    this.#listeners.forEach((listener) => listener());
+    Object.values(this.#listeners).forEach((listener) => listener());
   }
 
   async dispatch(actionKey: string, { ...payload }: DynamicObject = {}) {

--- a/front-end/src/pages/aboutus.ts
+++ b/front-end/src/pages/aboutus.ts
@@ -1,13 +1,7 @@
-import { OptionForm } from '@/components/OptionForm/OptionForm';
 import Component from '@/core/Component';
-import { qs } from '@/utils/querySelector';
 
 export class AboutUs extends Component {
   template(): string {
     return `<div id="option-form">about us page</div>`;
-  }
-  mounted(): void {
-    const form = qs('#option-form', this.target) as HTMLDivElement;
-    new OptionForm(form);
   }
 }

--- a/front-end/src/pages/aboutus.ts
+++ b/front-end/src/pages/aboutus.ts
@@ -1,7 +1,13 @@
+import { LoginForm } from '@/components/LoginForm/LoginForm';
 import Component from '@/core/Component';
+import { qs } from '@/utils/querySelector';
 
 export class AboutUs extends Component {
   template(): string {
     return `<div id="option-form">about us page</div>`;
+  }
+  mounted(): void {
+    const form = qs('#option-form', this.target) as HTMLDivElement;
+    new LoginForm(form);
   }
 }

--- a/front-end/src/pages/experiencing.ts
+++ b/front-end/src/pages/experiencing.ts
@@ -1,7 +1,23 @@
+import { ImageSlider } from '@/components/ImageSlider/ImageSlider';
+import { OptionForm } from '@/components/OptionForm/OptionForm';
+import { carList } from '@/constants/carList';
 import Component from '@/core/Component';
+import { qs } from '@/utils/querySelector';
 
 export class Experiencing extends Component {
   template(): string {
-    return `<div>Experiencing page</div>`;
+    return `
+    <div id="imageSlider"></div>
+    <div id="optionSelector"></div>
+    `;
+  }
+  mounted(): void {
+    const $imageSlider = qs('#imageSlider', this.target) as HTMLDivElement;
+    const $optionSelector = qs(
+      '#optionSelector',
+      this.target
+    ) as HTMLDivElement;
+    new ImageSlider($imageSlider, { list: carList });
+    new OptionForm($optionSelector);
   }
 }

--- a/front-end/src/store/OptionStore/OptionStore.ts
+++ b/front-end/src/store/OptionStore/OptionStore.ts
@@ -23,24 +23,22 @@ const reducer = (
   actionKey: string,
   payload: DynamicObject = {}
 ) => {
-  const newState: IOptionState = JSON.parse(JSON.stringify(state));
-
   switch (actionKey) {
     case 'OPTION_INIT':
       return initState;
 
     case 'ADD_CAR_OPTION':
-      newState.options.push(payload.option);
-      return newState;
+      const newOptions = [...state.options, payload.option];
+      return { state, options: newOptions };
 
     case 'DELETE_CAR_OPTION':
-      newState.options = newState.options.filter(
+      const filteredOptions = state.options.filter(
         (ele) => JSON.stringify(ele) !== JSON.stringify(payload.option)
       );
-      return newState;
+      return { ...state, options: filteredOptions };
 
     case 'SELECT_CAR_MODEL':
-      return { ...newState, carModel: payload.name };
+      return { ...state, carModel: payload.name };
 
     default:
       return { ...state };

--- a/front-end/src/store/OptionStore/OptionStore.ts
+++ b/front-end/src/store/OptionStore/OptionStore.ts
@@ -11,7 +11,7 @@ interface IOption {
 interface DynamicObject {
   [property: string]: any;
 }
-const initState = { carModel: null, rideTogether: false, options: [] };
+const initState = { carModel: '아반떼', rideTogether: false, options: [] };
 
 const reducer = (
   state: IOptionState,
@@ -33,6 +33,9 @@ const reducer = (
         (ele) => JSON.stringify(ele) !== JSON.stringify(payload.option)
       );
       return newState;
+
+    case 'SELECT_CAR_MODEL':
+      return { ...newState, carModel: payload.name };
 
     default:
       return { ...state };

--- a/front-end/src/store/OptionStore/OptionStore.ts
+++ b/front-end/src/store/OptionStore/OptionStore.ts
@@ -1,3 +1,4 @@
+import { carList } from '@/constants/carList';
 import { Store } from '@/core/Store.js';
 interface IOptionState {
   carModal: string | null;
@@ -11,7 +12,11 @@ interface IOption {
 interface DynamicObject {
   [property: string]: any;
 }
-const initState = { carModel: '아반떼', rideTogether: false, options: [] };
+const initState = {
+  carModel: carList[0].title,
+  rideTogether: false,
+  options: [],
+};
 
 const reducer = (
   state: IOptionState,

--- a/front-end/src/store/OptionStore/OptionStore.ts
+++ b/front-end/src/store/OptionStore/OptionStore.ts
@@ -28,19 +28,8 @@ const reducer = (
     case 'OPTION_INIT':
       return initState;
 
-    case 'ADD_CAR_OPTION':
-      const newOptions = [...state.options, payload.option];
-      return { state, options: newOptions };
-
-    case 'DELETE_CAR_OPTION':
-      const { option } = payload;
-      const filteredOptions = state.options.filter((ele) => {
-        return !(
-          ele.category.trim() === option.category.trim() &&
-          ele.name.trim() === option.name.trim()
-        );
-      });
-      return { ...state, options: filteredOptions };
+    case 'UPDATE_CAR_OPTION':
+      return { ...state, options: payload.options };
 
     case 'SELECT_CAR_MODEL':
       return { ...state, carModel: payload.name };

--- a/front-end/src/store/OptionStore/OptionStore.ts
+++ b/front-end/src/store/OptionStore/OptionStore.ts
@@ -8,6 +8,7 @@ interface IOptionState {
 interface IOption {
   name: string;
   category: string;
+  open: boolean;
 }
 interface DynamicObject {
   [property: string]: any;
@@ -32,9 +33,13 @@ const reducer = (
       return { state, options: newOptions };
 
     case 'DELETE_CAR_OPTION':
-      const filteredOptions = state.options.filter(
-        (ele) => JSON.stringify(ele) !== JSON.stringify(payload.option)
-      );
+      const { option } = payload;
+      const filteredOptions = state.options.filter((ele) => {
+        return !(
+          ele.category.trim() === option.category.trim() &&
+          ele.name.trim() === option.name.trim()
+        );
+      });
       return { ...state, options: filteredOptions };
 
     case 'SELECT_CAR_MODEL':

--- a/front-end/src/store/OptionStore/OptionStore.ts
+++ b/front-end/src/store/OptionStore/OptionStore.ts
@@ -17,6 +17,7 @@ const initState = {
   carModel: carList[0].title,
   rideTogether: false,
   options: [],
+  openState: [],
 };
 
 const reducer = (
@@ -28,11 +29,14 @@ const reducer = (
     case 'OPTION_INIT':
       return initState;
 
-    case 'UPDATE_CAR_OPTION':
+    case 'UPDATE_ACTIVE_CAR_OPTION':
       return { ...state, options: payload.options };
 
     case 'SELECT_CAR_MODEL':
       return { ...state, carModel: payload.name };
+
+    case 'UPDATE_OPEN_STATE':
+      return { ...state, openState: payload.openState };
 
     default:
       return { ...state };


### PR DESCRIPTION
### 이슈 넘버
- resolved #81

### 이런 이유로 코드를 변경했어요
- 옵션 셀렉터 데이터를 기반으로 렌더링 하기 위함

### 이런 작업을 했어요
- 스토어에 상태를 저장하고 그에 따른 렌더링

### 이런 위험이나 장애가 있어요
- 아직 사용하긴 좀 일러요
### 향후 이런 계획이 있어요
- 컴포넌트에서 store를 분리하기
- 달력, 지도와 연결하기
- 전체 옵션을 두고 버튼비활성화만 시키기
### 스크린샷
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/82891332/218294112-e23d14c9-597a-4da7-9dc6-d332a506eb43.gif)
