### PR TITLE
refactor(#112) 약관페이지 router에 따른 text 수정 및 리팩토링

### DIFF
--- a/front-end/src/components/Clauses/Clauses.ts
+++ b/front-end/src/components/Clauses/Clauses.ts
@@ -4,8 +4,18 @@ import styles from "./Clauses.module.scss";
 import { qs, qsa } from "@/utils/querySelector";
 
 export class Clauses extends Component {
+  setup(): void {
+    const status = document.location.href as string;
+    if (status.includes("sharing")) {
+      this.state.welcomeMessage = "소중한 경험을 공유해주셔서 감사합니다.";
+      this.state.status = "공유해주시기에 앞서, ";
+    } else {
+      this.state.welcomeMessage = "Experiences Begin Here";
+      this.state.status = "경험하기에 앞서, ";
+    }
+  }
   template(): string {
-    return literal();
+    return literal(this.state.welcomeMessage, this.state.status);
   }
 
   mounted(): void {

--- a/front-end/src/components/Clauses/Clauses.ts
+++ b/front-end/src/components/Clauses/Clauses.ts
@@ -18,30 +18,25 @@ export class Clauses extends Component {
     return literal(this.state.welcomeMessage, this.state.status);
   }
 
-  mounted(): void {
-    const form = qs("form")! as HTMLFormElement;
-    form.addEventListener("submit", (e: SubmitEvent) => e.preventDefault());
-    const checkbox = qsa("input")! as NodeListOf<HTMLInputElement>;
-
-    checkbox.forEach((box) => {
-      box.addEventListener("click", (_) => {
-        const nextBtn = qs(`.${styles["next-button"]}`)! as HTMLButtonElement;
-        if (allChecked()) {
-          nextBtn.disabled = false;
-          nextBtn.classList.toggle("active");
-        } else {
-          nextBtn.disabled = true;
-          nextBtn.classList.toggle("active");
-        }
-      });
-    });
-
-    function allChecked() {
-      const checkbox = qsa("input")! as NodeListOf<HTMLInputElement>;
-      for (const check of checkbox) {
-        if (!check.checked) return false;
+  setEvent(): void {
+    this.addEvent("submit", "form", (e) => e.preventDefault());
+    this.addEvent("click", "input", (_) => {
+      const nextBtn = qs(`.${styles["next-button"]}`)! as HTMLButtonElement;
+      if (this.isAllChecked()) {
+        nextBtn.disabled = false;
+        nextBtn.classList.toggle("active");
+      } else {
+        nextBtn.disabled = true;
+        nextBtn.classList.toggle("active");
       }
-      return true;
+    });
+  }
+
+  isAllChecked() {
+    const checkbox = qsa("input")! as NodeListOf<HTMLInputElement>;
+    for (const check of checkbox) {
+      if (!check.checked) return false;
     }
+    return true;
   }
 }

--- a/front-end/src/components/Clauses/template.ts
+++ b/front-end/src/components/Clauses/template.ts
@@ -1,6 +1,6 @@
 import styles from "./Clauses.module.scss";
 
-export const literal = () => {
+export const literal = (welcomeMessage: string, status: string) => {
   return `
   <div class=${styles["main-wrapper"]}>
       <div class=${styles["welcome-wrapper"]}>
@@ -10,9 +10,9 @@ export const literal = () => {
       <div class=${styles["texts-wrapper"]}>
         <div class=${styles["text-helper"]}></div>
         <div class=${styles["text-wrapper"]}>
-          <div class=${styles["text"]}>소중한 경험을 공유해주셔서 감사합니다.</div>
+          <div class=${styles["text"]}>${welcomeMessage}</div>
           <div class=${styles["text"]}>
-            공유해주시기에 앞서 아래의 약관에 동의해주세요.
+            ${status} 아래의 약관에 동의해주세요.
           </div>
         </div>
       </div>


### PR DESCRIPTION
### 이슈 넘버
- resolved #112 

### 이런 이유로 코드를 변경했어요
- Mid-Fi Prototype에서 사용자 입장에서 공유하기와 경험하기에서 나타나는 멘트(?)의 변화가 필요했어요.
- 이벤트 등록되는 방식이 Component에서 사용하는 방식과는 다르게 등록이 되어 있었어요
### 이런 작업을 했어요
- 유하기와 경험하기에서 나타나는 멘트(?)의 변화가 href의 상태에 따라 달라져요
- 이벤트 등록을 setEvent와 addEvent에서 처리해요
### 리뷰어는 여기에 집중해주시면 좋아요
- event등록 부분의 변화점에 집중해주시면 좋을 것 같습니다. 

### 이런 위험이나 장애가 있어요
- 아직은 잘 모르겠어요

### 향후 이런 계획이 있어요
- 약관에서 다음 버튼을 누르면 옵션 페이지가 link되어야 할 것 같아요
- 약관도 애니메이션으로 천천히 보이게 하고 싶습니다(?) 

### 스크린샷
![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/52685740/218297651-819af688-8f3c-4a2f-af8b-1ffe57340e99.gif)
