### PR TITLE
fix(#157): dropdown이 없을 때에도 close dropdown 메소드 실행되는 문제 해결

### DIFF
--- a/front-end/src/components/Navbar/Navbar.ts
+++ b/front-end/src/components/Navbar/Navbar.ts
@@ -72,6 +72,7 @@ export class Navbar extends Component {
 
   closeDropDown(e: Event) {
     const dropdownMenu = qs(`.${styles.dropdown}`) as HTMLDivElement;
+    if (!dropdownMenu) return;
     const target = e.target as Element;
     if (
       !target.closest('#user-icon') &&


### PR DESCRIPTION
### 이슈 넘버
- resolved #157

### 이런 이유로 코드를 변경했어요
- 네비게이션 바에서 드롭다운 메뉴가 없을때에도 close dropdown 을 호출해요
### 이런 작업을 했어요
- dropdown이 있을 때에만 호출하도록 수정했어요

