### PR TITLE
fix(#175) : Redis 구조를 제거하며 테스트 코드에 반영되지 않은 부분 수정 및 JWT 로직 개선 (이메일 추가, 불필요한 enum 삭제)

### DIFF
--- a/back-end/src/main/java/com/tdd/backend/auth/AuthResolver.java
+++ b/back-end/src/main/java/com/tdd/backend/auth/AuthResolver.java
@@ -1,7 +1,6 @@
 package com.tdd.backend.auth;
 
-import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenRole.*;
-import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenStatus.*;
+import static com.tdd.backend.auth.jwt.JwtProvider.JwtRole.*;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -43,7 +42,7 @@ public class AuthResolver implements HandlerMethodArgumentResolver {
 			throw new UnauthorizedException();
 		}
 
-		if (jwtProvider.validateToken(jws).equals(ACCESS)) {
+		if (jwtProvider.isValidateToken(jws)) {
 			if (!jwtProvider.getRoleFromJwt(jws).equals(ATK)) {
 				throw new InvalidTokenException();
 			}

--- a/back-end/src/main/java/com/tdd/backend/auth/jwt/JwtProvider.java
+++ b/back-end/src/main/java/com/tdd/backend/auth/jwt/JwtProvider.java
@@ -37,7 +37,7 @@ public class JwtProvider {
 	@Value("${app.jwt.refreshExpirationInMs}")
 	private int jwtRefreshExpirationInMs;
 
-	public String generateAccessToken(Long id) {
+	public String generateAccessToken(Long id, String email) {
 
 		Date now = new Date();
 		Date expiryDate = new Date(now.getTime() + jwtExpirationInMs);
@@ -46,6 +46,7 @@ public class JwtProvider {
 
 		return Jwts.builder()
 			.setSubject(String.valueOf(id))
+			.claim("email", email)
 			.claim("role", ATK)
 			.setIssuedAt(now)
 			.setExpiration(expiryDate)
@@ -53,7 +54,7 @@ public class JwtProvider {
 			.compact();
 	}
 
-	public String generateRefreshToken(Long id) {
+	public String generateRefreshToken(Long id, String email) {
 
 		Date now = new Date();
 		Date expiryDate = new Date(now.getTime() + jwtRefreshExpirationInMs);
@@ -62,6 +63,7 @@ public class JwtProvider {
 
 		return Jwts.builder()
 			.setSubject(String.valueOf(id))
+			.claim("email", email)
 			.claim("role", RTK)
 			.setIssuedAt(now)
 			.setExpiration(expiryDate)
@@ -76,6 +78,15 @@ public class JwtProvider {
 			.parseClaimsJws(authToken);
 
 		return Long.parseLong(claims.getBody().getSubject());
+	}
+
+	public String getEmailFromJwt(String authToken) {
+		Jws<Claims> claims = Jwts.parserBuilder()
+			.setSigningKey(decodeBase64(jwtSecret))
+			.build()
+			.parseClaimsJws(authToken);
+
+		return claims.getBody().get("email", String.class);
 	}
 
 	public JwtRole getRoleFromJwt(String authToken) {

--- a/back-end/src/main/java/com/tdd/backend/car/model/Car.java
+++ b/back-end/src/main/java/com/tdd/backend/car/model/Car.java
@@ -8,9 +8,9 @@ import lombok.Getter;
 @Table("cars")
 @Getter
 public class Car {
+	private final String carName;
 	@Id
 	private Long id;
-	private final String carName;
 
 	public Car(String carName) {
 		this.carName = carName;

--- a/back-end/src/main/java/com/tdd/backend/car/model/Option.java
+++ b/back-end/src/main/java/com/tdd/backend/car/model/Option.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 @Table("entire_options")
 @Getter
 public class Option {
-	@Id
-	private Long id;
 	private final String optionName;
 	private final String categoryName;
+	@Id
+	private Long id;
 
 	public Option(String optionName, String categoryName) {
 		this.optionName = optionName;

--- a/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
+++ b/back-end/src/main/java/com/tdd/backend/config/WebMvcConfig.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class WebMvcConfig implements WebMvcConfigurer {
 
 	private final JwtProvider jwtProvider;
+
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 		resolvers.add(new AuthResolver(jwtProvider));

--- a/back-end/src/main/java/com/tdd/backend/exception/ExceptionController.java
+++ b/back-end/src/main/java/com/tdd/backend/exception/ExceptionController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.tdd.backend.car.exception.CarNotFoundException;
 import com.tdd.backend.auth.exception.ExpiredATKException;
 import com.tdd.backend.auth.exception.InvalidTokenException;
+import com.tdd.backend.car.exception.CarNotFoundException;
 import com.tdd.backend.user.exception.DuplicateEmailException;
 import com.tdd.backend.user.exception.UnauthorizedException;
 import com.tdd.backend.user.exception.UserNotFoundException;

--- a/back-end/src/main/java/com/tdd/backend/post/controller/SharingController.java
+++ b/back-end/src/main/java/com/tdd/backend/post/controller/SharingController.java
@@ -25,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 public class SharingController {
 	private final SharingService sharingService;
 
-
 	@PostMapping("/sharing")
 	@Operation(summary = "차량 공유하기 요청", description = "차량 공유하기 시 Post 정보가 insert 되어야 합니다.")
 	@ApiResponse(responseCode = "302", description = "메인 페이지로 REDIRECT")

--- a/back-end/src/main/java/com/tdd/backend/post/controller/SharingController.java
+++ b/back-end/src/main/java/com/tdd/backend/post/controller/SharingController.java
@@ -32,6 +32,7 @@ public class SharingController {
 	public ResponseEntity<Void> shares(@LoginUser UserToken userToken,
 		@RequestBody @Valid SharingDto sharingDto) {
 		sharingService.save(sharingDto, userToken.getId());
+
 		HttpHeaders headers = new HttpHeaders();
 		headers.setLocation(URI.create("/"));
 		return new ResponseEntity<>(headers, HttpStatus.FOUND);

--- a/back-end/src/main/java/com/tdd/backend/user/controller/UserController.java
+++ b/back-end/src/main/java/com/tdd/backend/user/controller/UserController.java
@@ -4,12 +4,10 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tdd.backend.auth.data.JwtTokenPairResponse;

--- a/back-end/src/main/java/com/tdd/backend/user/data/User.java
+++ b/back-end/src/main/java/com/tdd/backend/user/data/User.java
@@ -3,11 +3,9 @@ package com.tdd.backend.user.data;
 import java.time.LocalDate;
 
 import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 import com.tdd.backend.mypage.data.UserInfo;
-import com.tdd.backend.post.model.Appointment;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -16,17 +14,13 @@ import lombok.Getter;
 @Getter
 public class User {
 
-	@Id
-	private Long id;
-
 	private final String email;
 	private final String userName;
 	private final String phoneNumber;
 	private final String userPassword;
 	private final LocalDate createdAt;
-
-	@Column("tester_id")
-	private Appointment appointment;
+	@Id
+	private Long id;
 
 	@Builder
 	private User(String email, String userName, String phoneNumber, String userPassword, LocalDate createdAt) {

--- a/back-end/src/main/java/com/tdd/backend/user/service/AuthService.java
+++ b/back-end/src/main/java/com/tdd/backend/user/service/AuthService.java
@@ -21,8 +21,8 @@ public class AuthService {
 	private final JwtProvider jwtProvider;
 
 	public JwtTokenPairResponse issueToken(User user) {
-		String accessToken = jwtProvider.generateAccessToken(user.getId());
-		String refreshToken = jwtProvider.generateRefreshToken(user.getId());
+		String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+		String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getEmail());
 		log.info("> access token : {}", accessToken);
 		log.info("> refresh token : {}", refreshToken);
 
@@ -32,19 +32,18 @@ public class AuthService {
 			.build();
 	}
 
-	// TODO : RTK도 만료시 재로그인 요청 보내야함 InvalidToken이랑 다름.
 	public JwtTokenPairResponse reIssueToken(String refreshToken) {
 		//리프레쉬 토큰이 validate 하고 유효한 RTK라면, 새로운 ATK 재발급
 		if (jwtProvider.isValidateToken(refreshToken)) {
 			if (!jwtProvider.getRoleFromJwt(refreshToken).equals(RTK)) {
 				throw new InvalidTokenException();
 			}
-			// TODO : ATK 재발급은 RTK의 payload에서 유저의 id를 꺼내며, 꺼내지는 지에 대한 Validation 처리 필요
-			// throw new UnauthorizedException();
-			Long id = jwtProvider.getUserIdFromJwt(refreshToken);
 
-			String newAccessToken = jwtProvider.generateAccessToken(id);
-			String newRefreshToken = jwtProvider.generateRefreshToken(id);
+			Long id = jwtProvider.getUserIdFromJwt(refreshToken);
+			String email = jwtProvider.getEmailFromJwt(refreshToken);
+
+			String newAccessToken = jwtProvider.generateAccessToken(id, email);
+			String newRefreshToken = jwtProvider.generateRefreshToken(id, email);
 			log.info(">> reissued access token : {}", newAccessToken);
 			log.info(">> reissued refresh token : {}", newRefreshToken);
 

--- a/back-end/src/main/java/com/tdd/backend/user/service/AuthService.java
+++ b/back-end/src/main/java/com/tdd/backend/user/service/AuthService.java
@@ -1,7 +1,6 @@
 package com.tdd.backend.user.service;
 
-import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenRole.*;
-import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenStatus.*;
+import static com.tdd.backend.auth.jwt.JwtProvider.JwtRole.*;
 
 import org.springframework.stereotype.Service;
 
@@ -36,7 +35,7 @@ public class AuthService {
 	// TODO : RTK도 만료시 재로그인 요청 보내야함 InvalidToken이랑 다름.
 	public JwtTokenPairResponse reIssueToken(String refreshToken) {
 		//리프레쉬 토큰이 validate 하고 유효한 RTK라면, 새로운 ATK 재발급
-		if (jwtProvider.validateToken(refreshToken) == ACCESS) {
+		if (jwtProvider.isValidateToken(refreshToken)) {
 			if (!jwtProvider.getRoleFromJwt(refreshToken).equals(RTK)) {
 				throw new InvalidTokenException();
 			}

--- a/back-end/src/test/http/driving.http
+++ b/back-end/src/test/http/driving.http
@@ -5,7 +5,7 @@ GET {{domain-address}}/test-driving/7
 ### 최종적인 예약 요청 ver2
 PATCH {{domain-address}}/appointments/2
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IkFUSyIsImlhdCI6MTY3NjQzNzEzOCwiZXhwIjoxNjc2NTIzNTM4fQ.viY5xrJhRQP3JcVljkxOUXUHEah4TZOnvautWNJC6Kc
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZSI6IkFUSyIsImlhdCI6MTY3NjUzMTU3NywiZXhwIjoxNjc2NTMzMzc3fQ.nNFWOu6uIeNHyiCXTOKwlJabelnouS0gAujDrKlL_0Q
 
 ###
 POST {{domain-address}}/test-driving/posts

--- a/back-end/src/test/http/sharing.http
+++ b/back-end/src/test/http/sharing.http
@@ -1,7 +1,7 @@
 ### 공유하기
 POST {{domain-address}}/sharing
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IkFUSyIsImlhdCI6MTY3NjQzNzEzOCwiZXhwIjoxNjc2NTIzNTM4fQ.viY5xrJhRQP3JcVljkxOUXUHEah4TZOnvautWNJC6Kc
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZSI6IkFUSyIsImlhdCI6MTY3NjUzMTU3NywiZXhwIjoxNjc2NTMzMzc3fQ.nNFWOu6uIeNHyiCXTOKwlJabelnouS0gAujDrKlL_0Q
 
 {
   "post": {

--- a/back-end/src/test/http/user.http
+++ b/back-end/src/test/http/user.http
@@ -20,4 +20,4 @@ Content-Type: application/json
 
 ### test auth
 GET {{domain-address}}/auth
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IkFUSyIsImlhdCI6MTY3NjQ1NDc0MSwiZXhwIjoxNjc2NDU2NTQxfQ.ZZbgv1VgzyvdfzEbKGrmWqo1Q6_3cdWBXh1uLolG7wk
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZSI6IkFUSyIsImlhdCI6MTY3NjUzMTU3NywiZXhwIjoxNjc2NTMzMzc3fQ.nNFWOu6uIeNHyiCXTOKwlJabelnouS0gAujDrKlL_0Q

--- a/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
+++ b/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
@@ -1,6 +1,5 @@
 package com.tdd.backend.auth.encrypt;
 
-import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenStatus.*;
 
 import java.security.Key;
 import java.util.Base64;
@@ -43,7 +42,7 @@ public class JwtEncryptTest {
 
 		//expected
 		SoftAssertions softAssertions = new SoftAssertions();
-		softAssertions.assertThat(jwtProvider.validateToken(jws)).isEqualTo(ACCESS);
+		softAssertions.assertThat(jwtProvider.isValidateToken(jws)).isTrue();
 		softAssertions.assertThat(jwtProvider.getUserIdFromJwt(jws)).isEqualTo(1L);
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
+++ b/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
@@ -46,6 +46,8 @@ public class JwtEncryptTest {
 		//expected
 		SoftAssertions softAssertions = new SoftAssertions();
 		softAssertions.assertThat(jwtProvider.isValidateToken(jws)).isTrue();
-		softAssertions.assertThat(jwtProvider.getUserIdFromJwt(jws)).isEqualTo(1L);
+		softAssertions.assertThat(jwtProvider.getUserIdFromJwt(jws)).isEqualTo(id);
+		softAssertions.assertThat(jwtProvider.getEmailFromJwt(jws)).isEqualTo(email);
+		softAssertions.assertAll();
 	}
 }

--- a/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
+++ b/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
@@ -38,7 +38,10 @@ public class JwtEncryptTest {
 	@Test
 	@DisplayName("JwtTokenProvider 빈 테스트")
 	void jwtTokenProvider_test() throws Exception {
-		String jws = jwtProvider.generateAccessToken(1L);
+		Long id = 1L;
+		String email = "test@test.com";
+
+		String jws = jwtProvider.generateAccessToken(1L, email );
 
 		//expected
 		SoftAssertions softAssertions = new SoftAssertions();

--- a/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
+++ b/back-end/src/test/java/com/tdd/backend/auth/encrypt/JwtEncryptTest.java
@@ -41,7 +41,7 @@ public class JwtEncryptTest {
 		Long id = 1L;
 		String email = "test@test.com";
 
-		String jws = jwtProvider.generateAccessToken(1L, email );
+		String jws = jwtProvider.generateAccessToken(1L, email);
 
 		//expected
 		SoftAssertions softAssertions = new SoftAssertions();

--- a/back-end/src/test/java/com/tdd/backend/post/PostControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/post/PostControllerTest.java
@@ -80,7 +80,7 @@ public class PostControllerTest {
 		mockMvc.perform(post("/sharing")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody)
-				.header("Authorization", jwtProvider.generateAccessToken(1L)))
+				.header("Authorization", jwtProvider.generateAccessToken(user.getId(), user.getEmail())))
 			.andExpect(status().isFound())
 			.andDo(print());
 		SoftAssertions soft = new SoftAssertions();

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -1,7 +1,6 @@
 package com.tdd.backend.user;
 
 import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenRole.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.springframework.http.HttpStatus.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -12,7 +11,6 @@ import java.util.Base64;
 import java.util.Date;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tdd.backend.auth.encrypt.EncryptHelper;
 import com.tdd.backend.auth.jwt.JwtProvider;
-import com.tdd.backend.auth.jwt.RefreshTokenService;
 import com.tdd.backend.user.controller.UserController;
 import com.tdd.backend.user.data.User;
 import com.tdd.backend.user.data.UserCreate;
@@ -56,14 +53,6 @@ class UserControllerTest {
 
 	@Autowired
 	JwtProvider jwtProvider;
-
-	@Autowired
-	RefreshTokenService refreshTokenService;
-
-	@BeforeEach
-	void setup() {
-		refreshTokenService.deleteAll();
-	}
 
 	@Test
 	@DisplayName("유저 회원가입")
@@ -259,7 +248,6 @@ class UserControllerTest {
 		//when
 		Long userId = 1L;
 		String refreshToken = jwtProvider.generateRefreshToken(userId);
-		refreshTokenService.saveRefreshToken(userId, refreshToken);
 
 		//expected
 		mockMvc.perform(post("/reissue")
@@ -292,26 +280,6 @@ class UserControllerTest {
 			)
 			.andExpect(status().isFound())
 			.andDo(print());
-	}
-
-	@Test
-	@DisplayName("로그아웃 시 RTK 스토리지에서 해당 key-value 쌍 삭제")
-	void logout_RTK_remove() throws Exception {
-		//given
-		Long userId = 1L;
-		String refreshToken = jwtProvider.generateRefreshToken(userId);
-		refreshTokenService.saveRefreshToken(userId, refreshToken);
-
-		//expected
-		mockMvc.perform(delete("/logout")
-				.header("Authorization", refreshToken)
-				.contentType(MediaType.APPLICATION_JSON)
-			)
-			.andExpect(status().isOk())
-			.andDo(print());
-
-		assertThat(refreshTokenService.isRefreshTokenExists(userId)).isFalse();
-
 	}
 
 	@Test

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -192,7 +192,7 @@ class UserControllerTest {
 			.build();
 
 		userRepository.save(user);
-		String jws = jwtProvider.generateAccessToken(user.getId());
+		String jws = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
 
 		//expected
 		mockMvc.perform(get("/auth")
@@ -247,7 +247,9 @@ class UserControllerTest {
 	void validate_RTK_expire_ATK() throws Exception {
 		//when
 		Long userId = 1L;
-		String refreshToken = jwtProvider.generateRefreshToken(userId);
+		String email = "test@test.com";
+
+		String refreshToken = jwtProvider.generateRefreshToken(userId, email);
 
 		//expected
 		mockMvc.perform(post("/reissue")
@@ -287,7 +289,8 @@ class UserControllerTest {
 	void check_validate_ATK() throws Exception {
 		//given
 		Long userId = 1L;
-		String rtk = jwtProvider.generateRefreshToken(userId);
+		String email = "test@test.com";
+		String rtk = jwtProvider.generateRefreshToken(userId, email);
 
 		//expected
 		mockMvc.perform(get("/auth")
@@ -304,7 +307,8 @@ class UserControllerTest {
 	void check_validate_RTK() throws Exception {
 		//given
 		Long userId = 1L;
-		String atk = jwtProvider.generateAccessToken(userId);
+		String email = "test@test.com";
+		String atk = jwtProvider.generateAccessToken(userId, email);
 
 		//expected
 		mockMvc.perform(post("/reissue")

--- a/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserControllerTest.java
@@ -1,6 +1,6 @@
 package com.tdd.backend.user;
 
-import static com.tdd.backend.auth.jwt.JwtProvider.JwtTokenRole.*;
+import static com.tdd.backend.auth.jwt.JwtProvider.JwtRole.*;
 import static org.springframework.http.HttpStatus.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;

--- a/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
+++ b/back-end/src/test/java/com/tdd/backend/user/UserServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tdd.backend.auth.encrypt.EncryptHelper;
-import com.tdd.backend.auth.jwt.RefreshTokenService;
 import com.tdd.backend.user.data.User;
 import com.tdd.backend.user.data.UserCreate;
 import com.tdd.backend.user.data.UserLogin;
@@ -33,9 +31,6 @@ class UserServiceTest {
 
 	@Autowired
 	private EncryptHelper encryptHelper;
-
-	@Autowired
-	RefreshTokenService refreshTokenService;
 
 	@Test
 	@DisplayName("유저 저장")
@@ -77,12 +72,8 @@ class UserServiceTest {
 		userService.login(userLogin);
 
 		//then
-		SoftAssertions softAssertions = new SoftAssertions();
 		User findUser = userRepository.findByEmail("test@test.com").orElseThrow(UserNotFoundException::new);
-		softAssertions.assertThat(findUser.getId()).isEqualTo(user.getId());
-
-		softAssertions.assertThat(refreshTokenService.isRefreshTokenExists(user.getId())).isTrue();
-		softAssertions.assertAll();
+		assertThat(findUser.getId()).isEqualTo(user.getId());
 	}
 
 	@Test


### PR DESCRIPTION
### 이슈 넘버
- resolved #175 

### 이런 이유로 코드를 변경했어요
- Redis를 제거하며 테스트코드를 수정하지 않아 오류가 발생하였습니다.
- 수정하는 김에 기능을 구현하며 email 정보도 JWT가 포함하고 있다면 불필요한 쿼리를 거치지 않고 바로 사용이 가능할 것이라 생각되어 코드를 개선해보고자 합니다.

### 이런 작업을 했어요
- 테스트코드에서 fail되던 부분을 고쳤습니다. (기존 redis에 캐시되어서 났던 오류들)
- 이제부터는 JWT토큰에서 user id 뿐 아니라 유저의 email도 가져올 수 있습니다!
- 가져오시려면 JwtProvider 클래스를 주입받아 getEmailFromJwt()를 호출해주시면 됩니다.

### 리뷰어는 여기에 집중해주시면 좋아요
- JwtProvider를 활용하면 유저 관련된 정보를 데이터베이스까지 가지 않고 가져올 수 있습니다. 확인해보시고 유저 관련해서 필요한 정보가 더 있거나 사용법이 궁금하시면 말씀해주세요!

### 이런 위험이나 장애가 있어요
- 혹시 인증이 잘 되지 않는다면 말씀해주세요!
