### PR TITLE
fix(#188): API 수정에 따른 이미지 render 방식 수정

### DIFF
--- a/front-end/src/components/DetailPage/DetailPage.ts
+++ b/front-end/src/components/DetailPage/DetailPage.ts
@@ -1,5 +1,4 @@
 import { getPosts } from '@/apis/detailPage';
-import { carList } from '@/constants/carList';
 import Component from '@/core/Component';
 import styles from './DetailPage.module.scss';
 
@@ -16,7 +15,7 @@ interface IOptions {
 
 export class DetailPage extends Component {
   async render() {
-    const res = await getPosts(4);
+    const res = await getPosts(1);
     this.setState({ res: res.data });
     this.target.innerHTML = this.template();
     this.mounted();
@@ -27,14 +26,12 @@ export class DetailPage extends Component {
   }
 
   template(): string {
-    const { appointments, location, options, post } = this.state.res;
+    const { appointments, imageUrl, location, options, post } = this.state.res;
     return `
       <div class="${styles['container']}">
         <div class="${styles['infos']}">
           <div class="${styles['image-wrapper']}">
-            <img class="${styles['image']}" src="${
-      process.env.VITE_IMAGE_URL
-    }/${this.findCarImage(post.carName)}" />
+            <img class="${styles['image']}" src="${imageUrl}" />
           </div>
           <div class="${styles['text-wrapper']}">
             <div class="${styles['car-name']}">
@@ -76,13 +73,6 @@ export class DetailPage extends Component {
         </div>
       </div>
     `;
-  }
-
-  findCarImage(carName: string) {
-    for (const car of carList) {
-      if (car.fileName.includes(carName.toLowerCase())) return car.fileName;
-    }
-    return 'error';
   }
 
   optionCreator(option: string): string {

--- a/front-end/src/components/DetailPage/DetailPage.ts
+++ b/front-end/src/components/DetailPage/DetailPage.ts
@@ -25,6 +25,15 @@ export class DetailPage extends Component {
     this.state = { ...this.state, ...newState };
   }
 
+  setEvent(): void {
+    this.addEvent('click', `.${styles['confirm']}`, (_) => {
+      window.location.href = '/mypage';
+    });
+    this.addEvent('click', `.${styles['cancel']}`, (_) => {
+      window.location.href = '/';
+    });
+  }
+
   template(): string {
     const { appointments, imageUrl, location, options, post } = this.state.res;
     return `

--- a/front-end/src/components/MyPage/MyPage.module.scss
+++ b/front-end/src/components/MyPage/MyPage.module.scss
@@ -114,7 +114,7 @@
             width: 100%;
             display: flex;
             .helper {
-              width: 25%;
+              width: 15%;
               height: 100%;
             }
             .image {

--- a/front-end/src/components/MyPage/MyPage.ts
+++ b/front-end/src/components/MyPage/MyPage.ts
@@ -4,7 +4,6 @@ import { qs } from '@/utils/querySelector';
 import { literal } from './template';
 import styles from './MyPage.module.scss';
 import { loadscript } from '@/utils/googleAPI';
-import { carList } from '@/constants/carList';
 
 interface IAppointment {
   date: string;
@@ -27,6 +26,7 @@ interface ISharing {
   post: {
     carName: string;
     id: number;
+    imageUrl: string;
     location: ILocation;
     options: IOptions[];
     requirement: string;
@@ -39,6 +39,7 @@ interface IDriving {
   post: {
     carName: string;
     id: number;
+    imageUrl: string;
     location: ILocation;
     options: IOptions[];
     requirement: string;
@@ -121,33 +122,26 @@ export class MyPage extends Component {
     $shrno.innerText = user.sharingCount as unknown as string;
   }
 
-  findCarImage(carName: string) {
-    const matched = carList.filter((car) => car.fileName.includes(carName));
-    return matched.length === 0 ? null : matched[0].fileName;
-  }
-
   generateDrivingCard(data: IDriving): string {
     const lat = +data.post.location.latitude;
     const lng = +data.post.location.longitude;
     const location = `https://www.google.co.kr/maps?&z=18.5&q=${lat},${lng}&ll=${lat},${lng}z`;
-    const carName = data.post.carName.toLowerCase();
-    const carImage = this.findCarImage(carName);
+    const carName = data.post.carName;
+    const carImage = data.post.imageUrl;
     const options = data.post.options;
     const date = data.date;
     return `
     <div class="${styles['card-wrapper']}">
       <div class=${styles['image-wrapper']}>
         <div class="${styles['helper']}"></div>
-        <img class="${styles['image']}" src="${
-      process.env.VITE_IMAGE_URL
-    }/${carImage}" />
+        <img class="${styles['image']}" src="${carImage}" />
       </div>
       <div class="${styles['text-wrapper']}">
         <div class="${styles['helper']}"></div>
         <div class="${styles['car-name']}">${carName}</div>
-        <div class="${styles['options']}">${options.map(
-      (ele) => ele.name
-    )}</div>
+        <div class="${styles['options']}">${options
+      .map((ele) => ele.name)
+      .join(', ')}</div>
         <div class="${styles['date']}">${date}</div>
         <div class="${styles['location']}">
           <a href="${location}" target="_blank">위치</a>
@@ -158,27 +152,28 @@ export class MyPage extends Component {
   }
 
   generateSharingCard(data: ISharing): string {
-    const carName = data.post.carName.toLowerCase();
-    const carImage = this.findCarImage(carName);
+    const carName = data.post.carName;
+    const carImage = data.post.imageUrl;
     const options = data.post.options;
     const lat = +data.post.location.latitude;
     const lng = +data.post.location.longitude;
+    const appointments = data.appointments;
     const location = `https://www.google.co.kr/maps?&z=18.5&q=${lat},${lng}&ll=${lat},${lng}z`;
     return `
     <div class=${styles['card-wrapper']}>
       <div class=${styles['image-wrapper']}>
         <div class=${styles['helper']}></div>
-        <img class="${styles['image']}" src="${
-      process.env.VITE_IMAGE_URL
-    }/${carImage}" />
+        <img class="${styles['image']}" src="${carImage}" />
       </div>
       <div class="${styles['text-wrapper']}">
         <div class="${styles['helper']}"></div>
         <div class="${styles['car-name']}">${carName}</div>
-        <div class="${styles['options']}">${options.map(
-      (ele) => ele.name
-    )}</div>
-        
+        <div class="${styles['options']}">${options
+      .map((ele) => ele.name)
+      .join(', ')}</div>
+        <div class="${styles['date']}">${appointments
+      .map((ele) => ele.date)
+      .join(', ')}</div>
         <div class="${styles['location']}">
           <a href="${location}" target="_blank">위치</a>
         </div>


### PR DESCRIPTION
### 이슈 넘버
- resolved #190 

### 이런 이유로 코드를 변경했어요
- image url을 프론트엔드쪽에서 찾고 있었는데 이 처리를 백엔드 분들이 image url을 넘겨주셨어요

### 이런 작업을 했어요
- 기존에 차 이름과 매칭시키는 작업을 하지 않고 받아온 데이터에서 url만 가지고 이미지를 뿌려줘요
- 디테일 페이지에서 확인 버튼을 누르면 마이페이지로, 취소 버튼을 누르면 home으로 이동해요.
### 리뷰어는 여기에 집중해주시면 좋아요
- 버튼을 눌렀을 때 redirect를 이런 방식으로 하는 방법이 맞는지 궁금해요

### 이런 위험이나 장애가 있어요
- 아직 확인하지 못했어요

### 향후 이런 계획이 있어요
- detail page에서 이제 예약 컨펌을 해야되요

### 스크린샷
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/52685740/219651359-2bf6e0ff-c0ab-4243-b1ce-31c58bd563fe.gif)


