### PR TITLE
fix(#201): 맵 컴포넌트 재배치

### DIFF
--- a/front-end/src/components/BulletinBoard/BulletinBoard.module.scss
+++ b/front-end/src/components/BulletinBoard/BulletinBoard.module.scss
@@ -3,7 +3,7 @@
   color: black;
   margin: auto;
   cursor: pointer;
-  padding: 20px;
+  padding: 10px;
   border-bottom: 1px solid #dee2e6;
   display: flex;
   max-width: 1000px;
@@ -14,14 +14,9 @@
     transition: 0.3s;
   }
   .left {
-    width: 85%;
+    width: 100%;
   }
-  .right {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 15%;
-  }
+
   .title {
     font-weight: bold;
   }

--- a/front-end/src/components/BulletinBoard/BulletinBoard.ts
+++ b/front-end/src/components/BulletinBoard/BulletinBoard.ts
@@ -25,6 +25,7 @@ export class BulletinBoard extends Component {
       const carName = ele.post.carName;
       return { title, options, dates, postId, carName, location: ele.location };
     });
+    if (filteredData.length === 0) return '<h4>검색 결과가 없습니다.</h4>';
     return filteredData.map((data: any) => this.listTemplate(data)).join('');
   }
 

--- a/front-end/src/components/BulletinBoard/BulletinBoard.ts
+++ b/front-end/src/components/BulletinBoard/BulletinBoard.ts
@@ -1,12 +1,14 @@
 import Component from '@/core/Component';
 import styles from './BulletinBoard.module.scss';
 import { ItestDrivingRes } from '@/store/OptionStore/interface';
+import { markerController } from '@/store/MarkerController';
 interface list {
   title: string;
   options: string;
   dates: string;
   carName: string;
   postId: number;
+  location: any;
 }
 
 export class BulletinBoard extends Component {
@@ -21,21 +23,31 @@ export class BulletinBoard extends Component {
       const dates = ele.appointments.map(({ date }) => date).join(' / ');
       const postId = ele.post.id;
       const carName = ele.post.carName;
-      return { title, options, dates, postId, carName };
+      return { title, options, dates, postId, carName, location: ele.location };
     });
     return filteredData.map((data: any) => this.listTemplate(data)).join('');
   }
 
   listTemplate(data: list) {
-    const { options, dates, carName, postId } = data;
+    const { options, dates, carName, location } = data;
     return `
-    <a data-link href="/details/${postId}" class="${styles.wrapper}">
+    <div data-location=${JSON.stringify(location)} class="${
+      styles.wrapper
+    } id="bulletinList">
       <div class="${styles.left}">
         <div class="${styles.title}">${carName || '제목 없음'}</div>
         <div class="${styles.contents}">${options}</div>
         <div class="${styles.info}">${dates}</div>
       </div>
-    </a>
+    </div>
     `;
+  }
+  setEvent(): void {
+    this.addEvent('click', `.${styles.wrapper}`, (e) => {
+      if (!(e.target instanceof Element)) return;
+      const $wrapper = e.target.closest(`.${styles.wrapper}`) as HTMLDivElement;
+      const location = JSON.parse($wrapper.dataset.location as string);
+      markerController.excuteListener(location);
+    });
   }
 }

--- a/front-end/src/components/BulletinBoard/BulletinBoard.ts
+++ b/front-end/src/components/BulletinBoard/BulletinBoard.ts
@@ -25,20 +25,15 @@ export class BulletinBoard extends Component {
     });
     return filteredData.map((data: any) => this.listTemplate(data)).join('');
   }
+
   listTemplate(data: list) {
-    const { title, options, dates, carName, postId } = data;
+    const { options, dates, carName, postId } = data;
     return `
-    <a data-link href="/mypage/${postId}" class="${styles.wrapper}">
+    <a data-link href="/details/${postId}" class="${styles.wrapper}">
       <div class="${styles.left}">
-        <div class="${styles.title}">${title || '제목 없음'}</div>
+        <div class="${styles.title}">${carName || '제목 없음'}</div>
         <div class="${styles.contents}">${options}</div>
         <div class="${styles.info}">${dates}</div>
-      </div>
-      <div class="${styles.right}">
-        <div class="${styles.circle}">
-          ${carName}
-          <div class="${styles['circle-text']}">${carName}</div>
-        </div>
       </div>
     </a>
     `;

--- a/front-end/src/components/DetailPage/DetailPage.ts
+++ b/front-end/src/components/DetailPage/DetailPage.ts
@@ -16,7 +16,8 @@ interface IOptions {
 
 export class DetailPage extends Component {
   async render() {
-    const res = await getPosts(4);
+    const postId = location.pathname.split('/').at(-1)!;
+    const res = await getPosts(+postId);
     this.setState({ res: res.data });
     this.target.innerHTML = this.template();
     this.mounted();

--- a/front-end/src/components/ExperienceMap/ExperienceMap.module.scss
+++ b/front-end/src/components/ExperienceMap/ExperienceMap.module.scss
@@ -5,10 +5,8 @@
   font-weight: normal;
   font-style: normal;
 }
-
 .googleMap {
-  width: 90%;
-  height: 700px;
+  height: 100%;
   margin: 0 auto;
 }
 

--- a/front-end/src/components/ExperienceMap/ExperienceMap.ts
+++ b/front-end/src/components/ExperienceMap/ExperienceMap.ts
@@ -30,7 +30,6 @@ export class ExperienceMap extends Component {
   template(): string {
     return `
     <div class=${styles.container}>
-      <div class="${styles.desc}">시승해보고 싶은 싶은 위치를 골라주세요!</div>
       <button class="${styles['find-my-position']} ${styles.jelly}">내 위치를 찾아줘..!</button>
       <span class="${styles.loader} ${styles.hidden}"></span>
     </div>
@@ -54,6 +53,7 @@ export class ExperienceMap extends Component {
       zoom: this.state.zoom,
       center: this.state.userLocation as google.maps.LatLng,
       styles: mapStyle() as object[],
+      disableDefaultUI: true,
     });
     this.state.map = map;
     this.moveMap();

--- a/front-end/src/components/ExperienceMap/ExperienceMap.ts
+++ b/front-end/src/components/ExperienceMap/ExperienceMap.ts
@@ -1,7 +1,6 @@
 import Component from '@/core/Component';
 import styles from './ExperienceMap.module.scss';
 import { mapStyle } from '@/utils/mapStyle';
-import { MarkerClusterer } from '@googlemaps/markerclusterer';
 import { loadscript } from '@/utils/googleAPI';
 import { qs } from '@/utils/querySelector';
 import { mapInfo } from './interface';
@@ -67,7 +66,7 @@ export class ExperienceMap extends Component {
       }, 500)
     );
 
-    this.refreshMap();
+    this.updateMarkers();
   }
 
   moveToMyLocation() {
@@ -78,6 +77,7 @@ export class ExperienceMap extends Component {
         ({ coords }) => {
           const { latitude, longitude } = coords;
           this.setMapPosition(latitude, longitude);
+
           this.hideSpinner();
         },
         () => {
@@ -98,6 +98,7 @@ export class ExperienceMap extends Component {
   moveMap() {
     this.state.map.panTo(this.state.userLocation);
   }
+
   updateMarkers() {
     this.showSpinner();
     const locations = this.props.store
@@ -112,22 +113,15 @@ export class ExperienceMap extends Component {
     this.createMarkers(locations);
     this.hideSpinner();
   }
+
   createMarkers(locations: google.maps.LatLng[]) {
-    const markers = locations.map(
+    this.state.markers = locations.map(
       (loc: google.maps.LatLng) =>
         new google.maps.Marker({
           position: loc,
           map: this.state.map,
         })
     );
-    this.state.markers = [...this.state.markers, ...markers];
-    const { map } = this.state;
-    new MarkerClusterer({ map, markers });
-  }
-
-  refreshMap() {
-    this.state.markers = [];
-    this.createMarkers([]);
   }
 
   handleDebounce(callback: Function, limit: number) {
@@ -161,8 +155,8 @@ export class ExperienceMap extends Component {
   setMapPosition(lat: number, lng: number, zoom: number | null = null) {
     const { map } = this.state;
     const newCenter = { lat, lng };
-    map.setCenter(newCenter);
-    zoom && map.setZoom(zoom);
+    map.panTo(newCenter, 1000, google.maps.Animation.BOUNCE);
+    zoom && map.setZoom(zoom, { animation: google.maps.Animation.BOUNCE });
   }
 
   clearMarkers() {
@@ -171,6 +165,7 @@ export class ExperienceMap extends Component {
     );
     this.state.markers = [];
   }
+
   setEvent(): void {
     this.addEvent(
       'click',

--- a/front-end/src/components/ExperienceMap/ExperienceMap.ts
+++ b/front-end/src/components/ExperienceMap/ExperienceMap.ts
@@ -76,8 +76,7 @@ export class ExperienceMap extends Component {
       navigator.geolocation.getCurrentPosition(
         ({ coords }) => {
           const { latitude, longitude } = coords;
-          this.setMapPosition(latitude, longitude);
-
+          this.setMapPosition(latitude, longitude, 17);
           this.hideSpinner();
         },
         () => {

--- a/front-end/src/components/OptionForm/OptionForm.module.scss
+++ b/front-end/src/components/OptionForm/OptionForm.module.scss
@@ -5,8 +5,8 @@
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   border-radius: 20px;
   font: normal 16px/26px system-ui, Roboto, Arial, sans-serif;
-  background: #fefefe;
-  color: #2a3744;
+  background: #4a4a4a;
+  color: white;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -webkit-text-size-adjust: none;
@@ -19,15 +19,11 @@
 .container__title {
   font-weight: 700;
   font-size: 16px;
-  background-color: #fff;
+  background-color: #4a4a4a;
   z-index: 2;
   position: relative;
-  color: #8fa6b3;
+  color: #fff;
   cursor: pointer;
-  &:hover {
-    font-size: 20px;
-  }
-  transition: font-size 0.3s;
 }
 
 .filter-container {
@@ -56,7 +52,7 @@
   cursor: pointer;
   display: inline-block;
   padding: 1px 8px;
-  color: #717171;
+  color: #fff;
   border: 1px solid #9b9b9b;
   border-radius: 25px;
   font-size: 14px;

--- a/front-end/src/components/OptionForm/OptionForm.module.scss
+++ b/front-end/src/components/OptionForm/OptionForm.module.scss
@@ -1,8 +1,7 @@
 .form-container {
   margin: 0 auto;
   padding: 10px 24px;
-  max-width: 900px;
-  width: 100%;
+  width: 900px;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   border-radius: 20px;
   font: normal 16px/26px system-ui, Roboto, Arial, sans-serif;

--- a/front-end/src/components/OptionForm/OptionForm.module.scss
+++ b/front-end/src/components/OptionForm/OptionForm.module.scss
@@ -22,7 +22,7 @@
   background-color: #4a4a4a;
   z-index: 2;
   position: relative;
-  color: #fff;
+  color: lightgray;
   cursor: pointer;
 }
 

--- a/front-end/src/constants/routeInfo.ts
+++ b/front-end/src/constants/routeInfo.ts
@@ -4,6 +4,7 @@ import { Sharing } from '@/pages/sharing';
 import { AboutUs } from '@/pages/aboutus';
 import { NotFound } from '@/pages/notfound';
 import { MyPage } from '@/components/MyPage/MyPage';
+import { DetailPage } from '@/components/DetailPage/DetailPage';
 interface IRoute {
   path: RegExp;
   element: Function;
@@ -16,5 +17,6 @@ export const routes: IRoute[] = [
   { path: /^\/experiencing$/, element: Experiencing },
   //test용
   { path: /^\/mypage$/, element: MyPage },
+  { path: /^\/details\/[\w]+$/, element: DetailPage },
   { path: /^\/post\/[\w]+$/, element: NotFound },
 ];

--- a/front-end/src/pages/experiencing.ts
+++ b/front-end/src/pages/experiencing.ts
@@ -17,17 +17,25 @@ export class Experiencing extends Component {
     <div class="${styles.container}">
       <div class="${styles.left}">
         <div class="${styles.buttons}">
-          <button>차종</button>
-          <button>옵션</button>
-          <button>날짜</button>
+          <div class="${styles.dropdown}">
+            <button class="${styles.dropbtn}">차종</button>
+            <div id="ex-imageSlider" class="${styles['dropdown-content']}"></div>
+          </div>
+          <div class="${styles.dropdown}">
+            <button class="${styles.dropbtn}">옵션</button>
+            <div id="ex-optionSelector" class="${styles['dropdown-content']}"></div>
+          </div>
+          <div class="${styles.dropdown}">
+            <button class="${styles.dropbtn}">날짜</button>
+            <div id="ex-calendar" class="${styles['dropdown-content']}"></div>
+          </div>
         </div>
-        <div id="bulletin-board" class="${styles.board}"></div>
+        <div class="${styles['board-cover']}">
+          <div id="bulletin-board" class="${styles.board}"></div>
+        </div>
       </div>
       <div id="ex-map" class="${styles.map}"></div>
     </div>
-    <div id="ex-imageSlider"></div>
-    <div id="ex-optionSelector"></div>
-    <div id="ex-calendar"></div>
     <div id="copy-link-btn"></div>
     `;
   }

--- a/front-end/src/pages/experiencing.ts
+++ b/front-end/src/pages/experiencing.ts
@@ -19,7 +19,7 @@ export class Experiencing extends Component {
         <div class="${styles.buttons}">
           <div class="${styles.dropdown}">
             <button class="${styles.dropbtn}">차종</button>
-            <div id="ex-imageSlider" class="${styles['dropdown-content']}"></div>
+            <div id="ex-imageSlider" class="${styles['dropdown-content']} ${styles.backdrop}"></div>
           </div>
           <div class="${styles.dropdown}">
             <button class="${styles.dropbtn}">옵션</button>

--- a/front-end/src/pages/experiencing.ts
+++ b/front-end/src/pages/experiencing.ts
@@ -14,14 +14,21 @@ import { CopyLinkBtn } from '@/components/CopyLinkBtn/CopyLinkBtn';
 export class Experiencing extends Component {
   template(): string {
     return `
-    <div id="ex-imageSlider"></div>
-    <div class="${styles['option-calendar-container']}">
-      <div id="ex-optionSelector"></div>
-      <div id="ex-calendar"></div>
+    <div class="${styles.container}">
+      <div class="${styles.left}">
+        <div class="${styles.buttons}">
+          <button>차종</button>
+          <button>옵션</button>
+          <button>날짜</button>
+        </div>
+        <div id="bulletin-board" class="${styles.board}"></div>
+      </div>
+      <div id="ex-map" class="${styles.map}"></div>
     </div>
-    <div id="ex-map"></div>
+    <div id="ex-imageSlider"></div>
+    <div id="ex-optionSelector"></div>
+    <div id="ex-calendar"></div>
     <div id="copy-link-btn"></div>
-    <div id="bulletin-board"><div>
     `;
   }
   mounted(): void {

--- a/front-end/src/store/MarkerController.ts
+++ b/front-end/src/store/MarkerController.ts
@@ -1,0 +1,13 @@
+import { Ilocation } from './OptionStore/interface';
+
+class MarkerController {
+  listener: any;
+  setListener(func: Function) {
+    this.listener = func;
+  }
+  excuteListener(location: Ilocation) {
+    const { latitude, longitude } = location;
+    this.listener(+latitude, +longitude);
+  }
+}
+export const markerController = new MarkerController();

--- a/front-end/src/store/OptionStore/interface.ts
+++ b/front-end/src/store/OptionStore/interface.ts
@@ -19,7 +19,7 @@ interface Iappointment {
   id: number;
   status: string;
 }
-interface Ilocation {
+export interface Ilocation {
   latitude: string;
   longitude: string;
 }

--- a/front-end/src/styles/experiencing.module.scss
+++ b/front-end/src/styles/experiencing.module.scss
@@ -23,7 +23,6 @@
   }
   .map {
     width: 80%;
-    border-left: 1px dashed;
   }
 }
 .dropdown {

--- a/front-end/src/styles/experiencing.module.scss
+++ b/front-end/src/styles/experiencing.module.scss
@@ -32,17 +32,20 @@
 }
 
 .dropbtn {
-  background-color: #4caf50;
+  background-color: #0095d9;
   color: white;
   padding: 12px;
   font-size: 16px;
   border: none;
+  box-shadow: 0 4px 8px 0 rgb(0 0 0 / 20%);
+  border-radius: 10px;
 }
 
 .dropdown-content {
   display: none;
   position: absolute;
   background-color: rgba(0, 0, 0, 0.4);
+  box-shadow: 0 14px 28px rgb(0 0 0 / 25%), 0 10px 10px rgb(0 0 0 / 22%);
   backdrop-filter: blur(3px);
   z-index: 100;
 }

--- a/front-end/src/styles/experiencing.module.scss
+++ b/front-end/src/styles/experiencing.module.scss
@@ -44,10 +44,13 @@
 .dropdown-content {
   display: none;
   position: absolute;
-  background-color: rgba(0, 0, 0, 0.4);
-  box-shadow: 0 14px 28px rgb(0 0 0 / 25%), 0 10px 10px rgb(0 0 0 / 22%);
-  backdrop-filter: blur(3px);
   z-index: 100;
+}
+
+.backdrop {
+  box-shadow: 0 14px 28px rgb(0 0 0 / 25%), 0 10px 10px rgb(0 0 0 / 22%);
+  background-color: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(3px);
 }
 
 .dropdown-content a {

--- a/front-end/src/styles/experiencing.module.scss
+++ b/front-end/src/styles/experiencing.module.scss
@@ -1,5 +1,30 @@
 .option-calendar-container {
   display: flex;
   justify-content: center;
-  margin: 3rem 0;
+}
+.container {
+  display: flex;
+  height: 85vh;
+  .left {
+    overflow-y: scroll;
+    width: 20%;
+    height: 100%;
+    .buttons {
+      display: flex;
+      justify-content: space-around;
+      margin-bottom: 10px;
+      position: absolute;
+      background-color: white;
+    }
+    .board {
+      margin-top: 30px;
+    }
+  }
+  .map {
+    width: 80%;
+    border-left: 1px dashed;
+  }
+  button {
+    margin: 0 20px 5px 20px;
+  }
 }

--- a/front-end/src/styles/experiencing.module.scss
+++ b/front-end/src/styles/experiencing.module.scss
@@ -6,15 +6,16 @@
   display: flex;
   height: 85vh;
   .left {
-    overflow-y: scroll;
     width: 20%;
     height: 100%;
     .buttons {
       display: flex;
       justify-content: space-around;
-      margin-bottom: 10px;
-      position: absolute;
       background-color: white;
+    }
+    .board-cover {
+      overflow-y: scroll;
+      height: 100%;
     }
     .board {
       margin-top: 30px;
@@ -24,7 +25,35 @@
     width: 80%;
     border-left: 1px dashed;
   }
-  button {
-    margin: 0 20px 5px 20px;
-  }
+}
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropbtn {
+  background-color: #4caf50;
+  color: white;
+  padding: 12px;
+  font-size: 16px;
+  border: none;
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(3px);
+  z-index: 100;
+}
+
+.dropdown-content a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+.dropdown:hover .dropdown-content {
+  display: block;
 }


### PR DESCRIPTION
### 이슈 넘버
- resolved #201

### 이런 이유로 코드를 변경했어요
- 지도가 아래 있어서 옵션을 선택할 때마다 스크롤을 내려야한다는 문제를 해결하기 위해..!
- 게시글과 지도의 marker가 어떻게 매칭되는지 알지 못하는 문제
### 이런 작업을 했어요
- 게시글은 왼쪽, 지도는 오른쪽으로 배치
- 차량, 옵션, 달력은 드롭다운으로 배치
- 게시글 눌렀을 때 마커로 찾아가도록 만듬
- 마커를 클릭하면 게시글의 링크가 info window로 나오도록 만듬
### 리뷰어는 여기에 집중해주시면 좋아요
- 더 적절한 ui가 있는지 생각해봐주시면 좋을것 같아요
### 이런 위험이나 장애가 있어요
- 맵이 움직일 때 마커가 다시 렌더링 되어 info window가 닫혀요
### 향후 이런 계획이 있어요
- 중복된 마커라면 다시 렌더링 되지 않도록 하면 좋을 것 같아요
### 스크린샷
![ezgif com-video-to-gif (10)](https://user-images.githubusercontent.com/82891332/220016134-647db652-2eb2-4041-a84a-ac253f7e4f78.gif)
![ezgif com-video-to-gif (11)](https://user-images.githubusercontent.com/82891332/220016746-702f3ab3-3b27-4fc9-97f1-a0061872f654.gif)
