### PR TITLE
refactor(#205) : 메일 전송 이벤트 처리

### DIFF
--- a/back-end/src/main/java/com/tdd/backend/mail/MailEventListener.java
+++ b/back-end/src/main/java/com/tdd/backend/mail/MailEventListener.java
@@ -1,0 +1,23 @@
+package com.tdd.backend.mail;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.tdd.backend.mail.service.MailService;
+import com.tdd.backend.post.service.DrivingService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MailEventListener {
+
+	private final MailService mailService;
+
+	@Async("mailExecutor")
+	@EventListener
+	public void handle(DrivingService.AppointmentMailEvent event) {
+		mailService.send(event.getAppointmentId(), event.getTesterId());
+	}
+}

--- a/back-end/src/main/java/com/tdd/backend/mail/service/MailService.java
+++ b/back-end/src/main/java/com/tdd/backend/mail/service/MailService.java
@@ -5,7 +5,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import com.tdd.backend.mail.data.EmailMessage;
@@ -29,7 +28,6 @@ public class MailService {
 	private final PostRepository postRepository;
 	private final UserRepository userRepository;
 
-	@Async("mailExecutor")
 	public void send(Long appointmentId, Long testerId) {
 		PostInfo postInfo = postRepository.findPostInfoByAppointmentId(appointmentId)
 			.orElseThrow(PostNotFoundException::new);


### PR DESCRIPTION
### 이슈 넘버
- resolved #205 

### 이런 이유로 코드를 변경했어요
- 현재 DrivingService에서는 MailService와 의존되어 있는 상태입니다. 이는 도메인 로직에 집중하지 못하는 코드가 될 수 있어 이벤트를 발행하는 방법을 통해 DrivingService와 MailService의 의존성을 끊어줄 수 있고 확장 가능한 구조가 될 수 있도록 합니다.
- 
### 이런 작업을 했어요
- Mail 서비스를 이벤트 처리하였습니다.

### 이런 위험이나 장애가 있어요
- 혹시나 배포 후 메일 전송에 문제가 있다면 꼭 말씀해주세요...
 
### 향후 이런 계획이 있어요
- AOP처리까지 목표로 하였으나 하지 않을 듯 싶습니다...!
