### PR TITLE
fix: appointments가 비었을 경우 리턴하지 않도록 수정

### DIFF
--- a/back-end/src/main/java/com/tdd/backend/post/service/DrivingService.java
+++ b/back-end/src/main/java/com/tdd/backend/post/service/DrivingService.java
@@ -107,6 +107,7 @@ public class DrivingService implements ApplicationEventPublisherAware {
 	private List<DrivingResponse> getDrivingResponses(List<Long> postIdList) {
 		return postIdList.stream()
 			.map(this::getAllDataByPostId)
+			.filter(drivingResponse -> !drivingResponse.getAppointments().isEmpty())
 			.collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
### 이슈 넘버
- resolved #233 

### 이런 이유로 코드를 변경했어요
- 날짜가 다 지났을 경우 날짜만 빈채로 응답이 가서 수정
### 이런 작업을 했어요
- 날짜가 다 지났을 경우 해당 포스틑 응답 안하도록 수정
- appointment가 비었을 경우 필터링 추가
### 리뷰어는 여기에 집중해주시면 좋아요
- 혹시 수정하실 부분이나 다른 에러가 있다면 같이 머지하겠습니다. 알려주세요!
